### PR TITLE
Option to hide the right-hand pane

### DIFF
--- a/rednotebook/configuration.py
+++ b/rednotebook/configuration.py
@@ -36,6 +36,7 @@ class Config(dict):
         'previewFont': 'Ubuntu, mingliu, MS Mincho, sans-serif',
         'closeToTray': 0,
         'checkForNewVersion': 0,
+        'enable_annotations_pane': 1,
         'weekNumbers': 0,
         'portable': 0,
         'userDir': '',

--- a/rednotebook/configuration.py
+++ b/rednotebook/configuration.py
@@ -36,7 +36,7 @@ class Config(dict):
         'previewFont': 'Ubuntu, mingliu, MS Mincho, sans-serif',
         'closeToTray': 0,
         'checkForNewVersion': 0,
-        'enable_annotations_pane': 1,
+        'showTagsPane': 1,
         'weekNumbers': 0,
         'portable': 0,
         'userDir': '',

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -191,6 +191,14 @@ class MainWindow(object):
         self.set_tooltips()
         self.setup_tray_icon()
 
+        # Enable/disable the "tags" pane on the right
+        self.annotations_pane = self.builder.get_object('annotations_pane')
+        if self.journal.config.read('enable_annotations_pane') == 1:
+            self.annotations_pane.show()
+        else:
+            self.annotations_pane.hide()
+
+
     def set_tooltips(self):
         '''
         Little work-around:

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -193,7 +193,7 @@ class MainWindow(object):
 
         # Enable/disable the "tags" pane on the right
         self.annotations_pane = self.builder.get_object('annotations_pane')
-        if self.journal.config.read('enable_annotations_pane') == 1:
+        if self.journal.config.read('showTagsPane') == 1:
             self.annotations_pane.show()
         else:
             self.annotations_pane.hide()

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -279,7 +279,7 @@ class OptionsManager(object):
         check_version_option = TickOption(_('Check for new version at startup'), 'checkForNewVersion')
 
         # Enable/Disable right-hand pane
-        self.options.append(TickOption(_('Enable Annotations Pane (Tags)'),'enable_annotations_pane', default=0))
+        self.options.append(TickOption(_('Show right-side tags pane'),'showTagsPane'))
 
         def check_version_action(widget):
             utils.check_new_version(self.main_window.journal, info.version)
@@ -319,7 +319,7 @@ class OptionsManager(object):
             self.main_window.tray_icon.set_visible(visible)
 
             # Enable/disable the "tags" pane on the right
-            if self.config.read('enable_annotations_pane') == 1:
+            if self.config.read('showTagsPane') == 1:
                 self.main_window.annotations_pane.show()
             else:
                 self.main_window.annotations_pane.hide()

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -278,6 +278,9 @@ class OptionsManager(object):
         # Check for new version
         check_version_option = TickOption(_('Check for new version at startup'), 'checkForNewVersion')
 
+        # Enable/Disable right-hand pane
+        self.options.append(TickOption(_('Enable Annotations Pane (Tags)'),'enable_annotations_pane', default=0))
+
         def check_version_action(widget):
             utils.check_new_version(self.main_window.journal, info.version)
             # Apply changes from dialog to options window
@@ -314,6 +317,13 @@ class OptionsManager(object):
 
             visible = (self.config.read('closeToTray') == 1)
             self.main_window.tray_icon.set_visible(visible)
+
+            # Enable/disable the "tags" pane on the right
+            if self.config.read('enable_annotations_pane') == 1:
+                self.main_window.annotations_pane.show()
+            else:
+                self.main_window.annotations_pane.hide()
+
         else:
             # Reset some options
             self.main_window.set_font(self.config.read('mainFont', editor.DEFAULT_FONT))


### PR DESCRIPTION
I never use the right-hand annotations or "tags" pane, so I added an option to hide it.  I thought other users might find this useful, so I figured I'd share.

Rednotebook is a fantastic tool that I have used for years.  Thanks for putting the source on GitHub!