### PR TITLE
Avoid file overwrite on save, when external application changed files after file load

### DIFF
--- a/rednotebook/data.py
+++ b/rednotebook/data.py
@@ -260,7 +260,7 @@ class Day(object):
 
 
 class Month(object):
-    def __init__(self, year_number, month_number, month_content=None):
+    def __init__(self, year_number, month_number, month_content=None, mtime=0):
         self.year_number = year_number
         self.month_number = month_number
 
@@ -270,6 +270,7 @@ class Month(object):
             self.days[day_number] = Day(self, day_number, day_content)
 
         self.edited = False
+        self.mtime = mtime
 
     def get_day(self, day_number):
         if day_number not in self.days:

--- a/rednotebook/storage.py
+++ b/rednotebook/storage.py
@@ -135,9 +135,11 @@ def _save_month_to_disk(month, journal_dir):
         yaml.dump(content, f, Dumper=Dumper, allow_unicode=True)
 
     if os.path.exists(filename):
-        if os.path.getmtime(filename)!=month.mtime:
-            conflict = get_filename('.CONFLICT_BACKUP'+str(os.path.getmtime(filename)))
-            logging.debug('Last edit time of %s conflicts with edit time at file load\n --> Backing up to %s' % (filename, conflict))
+        mtime = os.path.getmtime(filename)
+        if mtime != month.mtime:
+            conflict = get_filename('.CONFLICT_BACKUP' + str(mtime))
+            logging.debug('Last edit time of %s conflicts with edit time at file load\n'
+                          '--> Backing up to %s' % (filename, conflict))
             shutil.copy2(filename, conflict)
         shutil.copy2(filename, old)
     shutil.move(new, filename)
@@ -152,7 +154,7 @@ def _save_month_to_disk(month, journal_dir):
 
     month.edited = False
     month.mtime = os.path.getmtime(filename)
-    logging.debug('Wrote file %s' % filename)
+    logging.info('Wrote file %s' % filename)
     return True
 
 

--- a/rednotebook/storage.py
+++ b/rednotebook/storage.py
@@ -74,7 +74,7 @@ def _load_month_from_disk(path, year_number, month_number):
         with codecs.open(path, 'rb', encoding='utf-8') as month_file:
             logging.debug('Loading file "%s"' % path)
             month_contents = yaml.load(month_file, Loader=Loader)
-            month = Month(year_number, month_number, month_contents)
+            month = Month(year_number, month_number, month_contents, os.path.getmtime(path))
             return month
     except yaml.YAMLError, exc:
         logging.error('Error in file %s:\n%s' % (path, exc))
@@ -135,6 +135,10 @@ def _save_month_to_disk(month, journal_dir):
         yaml.dump(content, f, Dumper=Dumper, allow_unicode=True)
 
     if os.path.exists(filename):
+        if os.path.getmtime(filename)!=month.mtime:
+            conflict = get_filename('.CONFLICT_BACKUP'+str(os.path.getmtime(filename)))
+            logging.debug('Last edit time of %s conflicts with edit time at file load\n --> Backing up to %s' % (filename, conflict))
+            shutil.copy2(filename, conflict)
         shutil.copy2(filename, old)
     shutil.move(new, filename)
     if os.path.exists(old):
@@ -147,6 +151,7 @@ def _save_month_to_disk(month, journal_dir):
         pass
 
     month.edited = False
+    month.mtime = os.path.getmtime(filename)
     logging.debug('Wrote file %s' % filename)
     return True
 


### PR DESCRIPTION
**Problem**
rednotebook will overwrite txt-files in the notebook directory on saving, even when an external program has changed such a file meanwhile. This deletes any external changes on autosave or on accidental saving. This is especially interesting, when a notebook is synced with a cloud. My specific case is the following: a notebook is edited on device A and left open after editing. Later, the notebook is opened on device B, changes are made and saved. These changes are synced to A but not recognized by rednotebook still running on A. So saving will discard any changes that were made on device B.

**Solution**
At file opening, store date of last file edit in object "Month". When saving, check whether date of last file edit has changed, i.e. file has been edited by an external program. If dates differ, rename file on disk using the last-edited timestamp as part of the new filename. Refresh date of last file edit in object "Month".

**TODOs**
There is only a command line notification in my solution to the problem. It would be nice to give graphical feedback. Maybe let the user choose, whether or where to save a backup? Or whether local changes should be discarded?

I am looking forward to feedback!
Best, Felix