### PR TITLE
Added missing slash in configuration directory path

### DIFF
--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -82,7 +82,7 @@ class TickOption(Option):
 class AutostartOption(TickOption):
     def __init__(self):
         self.autostart_file = os.path.expanduser(
-            '~.config/autostart/rednotebook.desktop')
+            '~/.config/autostart/rednotebook.desktop')
         autostart_file_exists = os.path.exists(self.autostart_file)
         TickOption.__init__(
             self, _('Load RedNotebook at startup'), None, value=autostart_file_exists)


### PR DESCRIPTION
There was missing slash in the configuration path to be expanded to the user's home, which was causing the options window to never close when the "Load RedNotebook at startup" choice is selected.

This solves this bug: https://bugs.launchpad.net/rednotebook/+bug/1628497