### PR TITLE
Commit changes...

### DIFF
--- a/data/rednotebook.appdata.xml
+++ b/data/rednotebook.appdata.xml
@@ -6,9 +6,9 @@
   <name>RedNotebook</name>
   <summary>Graphical diary and journal</summary>
   <description>
-    <p>Modern desktop journal. It lets you format, tag
-    and search your entries. You can also add pictures, links and
-    customizable templates, spell check your notes, and export to plain
+    <p>Modern desktop diary and personal journaling tool. It lets you format,
+    tag and search your entries. You can also add pictures, links and
+    customisable templates, spell check your notes, and export to plain
     text, HTML, LaTeX or PDF.</p>
   </description>
   <url type="homepage">http://rednotebook.sourceforge.net</url>

--- a/debian/changelog
+++ b/debian/changelog
@@ -18,7 +18,7 @@ rednotebook (2.2-1) unstable; urgency=medium
   * Remove debian/menu - Not necessary and causes lintian warning.
   * Remove debian/README.sources - Not needed.
   * Eliminate lintian pedantic warnings that are checked on the upload servers.
-  * Updated debian changelog.
+  * Updated debian changelog - Various fixes.
   * ITP: Submission of RedNotebook version 2.x. (Closes: #875264)
 
  -- Phil Wyett <philwyett@kathenas.org>  Sat, 09 Sep 2017 23:57:57 +0100

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,22 +1,27 @@
-rednotebook (2.2-2) unstable; urgency=medium
+rednotebook (2.2-1) unstable; urgency=medium
 
-  * Maintainer change.
-  * ITP: Submission of RedNotebook version 2.x. (Closes: #875264)
+  [ Jendrik Seipp ]
+  * New upstream release
+  * Port RedNotebook 2 to Windows.
+  * Windows: uninstall old version before installing new version to remove
+    old files.
+  * Windows: use Aspell for spell checking.
 
   [ Omar Jair Purata Funes ]
   * Team contribution - debug and packaging.
 
+  [ Phil Wyett ]
+  * Maintainer change.
+  * Add patch: appdata_path_and_description.patch
+    - Update appdata install path.
+    - Update description in appdata file to match debian control file.
+  * Remove debian/menu - Not necessary and causes lintian warning.
+  * Remove debian/README.sources - Not needed.
+  * Eliminate lintian pedantic warnings that are checked on the upload servers.
+  * Updated debian changelog.
+  * ITP: Submission of RedNotebook version 2.x. (Closes: #875264)
+
  -- Phil Wyett <philwyett@kathenas.org>  Sat, 09 Sep 2017 23:57:57 +0100
-
-rednotebook (2.2-1) UNRELEASED; urgency=low
-
-  * New upstream release
-  * Port RedNotebook 2 to Windows.
-  * Windows: uninstall old version before installing new version to remove old files.
-  * Windows: use Aspell for spell checking.
-  * Update Debian files (@kathenas).
-
- -- Jendrik Seipp <jendrikseipp@web.de>  Fri, 08 Sep 2017 19:52:14 +0200
 
 rednotebook (2.1.5-1) UNRELEASED; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Depends: ${python3:Depends},
          python3-gi,
          python3-yaml
 Recommends: python3-enchant
-Description: Modern desktop journal. It lets you format, tag and search
- your entries. You can also add pictures, links and customizable templates,
- spell check your notes, and export to plain text, HTML, LaTeX or PDF.
+Description: Modern desktop diary and personal journaling tool. It lets you
+ format, tag and search your entries. You can also add pictures, links and
+ customisable templates, spell check your notes, and export to plain text,
+ HTML, LaTeX or PDF.

--- a/debian/copyright
+++ b/debian/copyright
@@ -62,7 +62,7 @@ License: GPL-3+
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-3".
 
 Files: rednotebook/external/txt2tags.py
-Copyright: Copyright 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Aurelio Jargas
+Copyright: Copyright 2001-2010 Aurelio Jargas
 License: GPL-2+
 
 License: GPL-2+

--- a/debian/copyright
+++ b/debian/copyright
@@ -7,34 +7,13 @@ License: GPL-2+
 
 Files: debian/*
 Copyright: Copyright (C) 2008, 2009 Jonathan Wiltshire <debian@jwiltshire.org.uk>
+           Copyright (C) 2010-2017 Jendrik Seipp <jendrikseipp@gmail.com>
            Copyright (C) 2017 Phil Wyett <philwyett@kathenas.org>
 License: GPL-2+
 
 Files: po/*.po
 Copyright: Copyright (C) 2009 Rosetta Contributors and Canonical Ltd.
 License: GPL-2+
-
-License: GPL-2+
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
- .
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- `/usr/share/common-licenses/GPL-2'.
 
 Files: rednotebook/external/elibintl.py
 Copyright: Copyright (C) 2007-2010 Dieter Verfaillie <dieterv@optionexplicit.be>
@@ -84,19 +63,26 @@ License: GPL-3+
 
 Files: rednotebook/external/txt2tags.py
 Copyright: Copyright 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Aurelio Jargas
-License: GPL-2
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, version 2.
+License: GPL-2+
+
+License: GPL-2+
+ This program is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later
+ version.
  .
- This package is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+ This program is distributed in the hope that it will be
+ useful, but WITHOUT ANY WARRANTY; without even the implied
+ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU General Public License for more
+ details.
  .
- You should have received a copy of the GNU General Public License
- along with this package; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ You should have received a copy of the GNU General Public
+ License along with this package; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA  02110-1301 USA
  .
- On Debian systems, the full text of the GPL can be found at
- /usr/share/common-licenses/GPL-2'.
+ On Debian systems, the full text of the GNU General Public
+ License version 2 can be found in the file
+ `/usr/share/common-licenses/GPL-2'.

--- a/debian/copyright
+++ b/debian/copyright
@@ -7,6 +7,7 @@ License: GPL-2+
 
 Files: debian/*
 Copyright: Copyright (C) 2008, 2009 Jonathan Wiltshire <debian@jwiltshire.org.uk>
+           Copyright (C) 2017 Phil Wyett <philwyett@kathenas.org>
 License: GPL-2+
 
 Files: po/*.po


### PR DESCRIPTION
* Update description in 'debian/control' and fix minor warning that
  description was too short.
* Update description in appdata file to match debian control file.
* Add myself to copyright file for 'debian/*'.
* Update changelog. Debian mentor wanted total rollup of 2.2-* into one entry.

Note 1: Jendrik. You need to add a copyright entry to same section as I have
            done. Debian mentor(s) are being exceptionally picky.

Note 2: Ignore reference to appdata patch. This avoids having to create a new
            release and all changes in the patch are in the git repo.