### PR TITLE
Enable entry reference links in exported HTML

### DIFF
--- a/rednotebook/files/t2t.lang
+++ b/rednotebook/files/t2t.lang
@@ -255,7 +255,7 @@
     </context>
 
     <context id="entry-reference" style-ref="entry-reference">
-      <match>(([^#\[])|^)\d{4}-\d{2}-\d{2}</match>
+      <match>(([^#\[_])|^)\d{4}-\d{2}-\d{2}</match>
     </context>
 
     <context id="named-entry-reference">

--- a/rednotebook/gui/exports.py
+++ b/rednotebook/gui/exports.py
@@ -413,7 +413,7 @@ class ExportAssistant(Assistant):
     def yes_no(self, value):
         return _('Yes') if value else _('No')
 
-    def get_export_string(self, format):
+    def get_export_string(self, target):
         if self.export_selected_text and self.page2.selected_text:
             markup_string = self.page2.selected_text
         else:
@@ -437,7 +437,9 @@ class ExportAssistant(Assistant):
                 if include_day:
                     date_format = self.journal.config.read('exportDateFormat')
                     date_string = dates.format_date(date_format, day.date)
-                    day_markup = markup.get_markup_for_day(day, with_text=self.page3.is_text_included(),
+                    day_markup = markup.get_markup_for_day(day,
+                                                           target,
+                                                           with_text=self.page3.is_text_included(),
                                                            with_tags=self.page3.is_tags_included(),
                                                            categories=selected_categories,
                                                            date=date_string)
@@ -445,7 +447,7 @@ class ExportAssistant(Assistant):
 
             markup_string = ''.join(markup_strings_for_each_day)
 
-        return self.journal.convert(markup_string, format, options={'toc': 0, 'export_to_file': True})
+        return self.journal.convert(markup_string, target, options={'toc': 0, 'export_to_file': True})
 
     def export(self):
         format = self.exporter.FORMAT

--- a/rednotebook/gui/exports.py
+++ b/rednotebook/gui/exports.py
@@ -447,7 +447,7 @@ class ExportAssistant(Assistant):
 
             markup_string = ''.join(markup_strings_for_each_day)
 
-        return self.journal.convert(markup_string, target, options={'toc': 0, 'export_to_file': True})
+        return self.journal.convert(markup_string, target, options={'toc': 0})
 
     def export(self):
         format = self.exporter.FORMAT

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -295,11 +295,15 @@ def _get_config(target, options):
 
         config['postproc'].append([COLOR_ESCAPED, r'\\textcolor{\2}{\1}'])
 
+        config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
+
         # Links to entry references are not supported in TeX export - we rewrite them here.
         config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\]',
                                   r'\g<name> (\g<date>)'])
 
     elif target == 'txt':
+        config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
+
         # Line breaks
         config['postproc'].append([r'LINEBREAK', '\n'])
 

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -146,7 +146,11 @@ def get_markup_for_day(day, with_text=True, with_tags=True, categories=None, dat
 
     # Add date if it is not None and not the empty string
     if date:
-        export_string += '= %s =\n\n' % date
+        # Following anchor placeholder will be used as a target for every entry reference
+        # mentioning this entry's date. In postprocessing it will be replaced by relevant HTML tag.
+        date_anchor = 'DATE_ANCHOR_PLACEHOLDER_%s' % day.date.strftime('%Y-%m-%d')
+
+        export_string += '= %s %s =\n\n' % (date_anchor, date)
 
     # Add text
     if with_text:
@@ -228,21 +232,21 @@ def _get_config(target, options):
 
         # Entry references
         if is_exporting_to_file:
-            # When exporting we need to remove entry reference links because
-            # they are only valid within our app.
-            config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
-                                      r'\g<name> (\g<date>)'])
-        else:
-            # txt2tags will generate links to the named entry references because they share common bracket
-            # notation used by the URIs. We just need to add our internal schema to make it a proper URI.
-            config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
-                                      r'[\g<name> #\g<date>]'])
+            # `get_markup_for_day` will generate placeholders which we need to override in order to create
+            # anchor targets for entry reference links to point to.
+            config['postproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2})',
+                                      r'<span id="\g<date>"></span>'])
 
-            # Stand alone dates are converted into named references where the date itself is being
-            # used as a name. For example:
-            # "Today is 2019-10-20" will be converted into "Today is [2019-10-20 notebook:2019-10-20]"
-            config['preproc'].append([r'(?<!#|\[|_)(?P<date>\d{4}-\d{2}-\d{2})',
-                                      r'[\g<date> #\g<date>]'])
+        # txt2tags will generate links to the named entry references because they share common bracket
+        # notation used by the URIs. We just need to add our internal schema to make it a proper URI.
+        config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
+                                  r'[\g<name> #\g<date>]'])
+
+        # Stand alone dates are converted into named references where the date itself is being
+        # used as a name. For example:
+        # "Today is 2019-10-20" will be converted into "Today is [2019-10-20 #2019-10-20]"
+        config['preproc'].append([r'(?<!#|\[|_)(?P<date>\d{4}-\d{2}-\d{2})',
+                                  r'[\g<date> #\g<date>]'])
 
     elif target == 'tex':
         config['encoding'] = 'utf8'

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -227,23 +227,7 @@ def _get_config(target, options):
         # {{red text|color:red}} -> <span style="color:red">red text</span>
         config['postproc'].append([COLOR_ESCAPED, r'<span style="color:\2">\1</span>'])
 
-        # Entry references
 
-        # `get_markup_for_day` will generate placeholders which we need to override in order to create
-        # anchor targets for entry reference links to point to.
-        config['postproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2})',
-                                  r'<span id="\g<date>"></span>'])
-
-        # txt2tags will generate links to the named entry references because they share common bracket
-        # notation used by the URIs. We just need to add our internal schema to make it a proper URI.
-        config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
-                                  r'[\g<name> #\g<date>]'])
-
-        # Convert bracketed dates into named references where the date itself is being used as a name.
-        # For example:
-        # "Today is [2019-10-20]" will be converted into "Today is [2019-10-20 #2019-10-20]"
-        config['preproc'].append([r'\[(?P<date>\d{4}-\d{2}-\d{2})\]',
-                                  r'[\g<date> #\g<date>]'])
 
         # Custom css
         fonts = options.pop('font', 'sans-serif')
@@ -302,22 +286,37 @@ def _get_config(target, options):
 
         config['postproc'].append([COLOR_ESCAPED, r'\\textcolor{\2}{\1}'])
 
-        # Remove day anchor placeholders
-        config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
-
-        # Links to entry references are not supported in TeX export - we rewrite them here.
-        config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\]',
-                                  r'\g<name> (\g<date>)'])
-
     elif target == 'txt':
-        # Remove day anchor placeholders
-        config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
-
         # Line breaks
         config['postproc'].append([r'LINEBREAK', '\n'])
 
         # Apply image resizing ([WIDTH400-file:///pathtoimage.jpg])
         config['postproc'].append([r'\[WIDTH(\d+)-(.+)\]', r'[\2?\1]'])
+
+    # Entry references
+    if target in ['xhtml', 'html']:
+        # `get_markup_for_day` will generate placeholders which we need to override in order to create
+        # anchor targets for entry reference links to point to.
+        config['postproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2})',
+                                   r'<span id="\g<date>"></span>'])
+
+        # txt2tags will generate links to the named entry references because they share common bracket
+        # notation used by the URIs. We just need to add our internal schema to make it a proper URI.
+        config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
+                                  r'[\g<name> #\g<date>]'])
+
+        # Convert bracketed dates into named references where the date itself is being used as a name.
+        # For example:
+        # "Today is [2019-10-20]" will be converted into "Today is [2019-10-20 #2019-10-20]"
+        config['preproc'].append([r'\[(?P<date>\d{4}-\d{2}-\d{2})\]',
+                                  r'[\g<date> #\g<date>]'])
+    else:
+        # Remove day anchor placeholders
+        config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
+
+        # Links to entry references are not supported for targets other than (X)HTML
+        config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\]',
+                                  r'\g<name> (\g<date>)'])
 
     # Allow resizing images by changing
     # [filename.png?width] to [WIDTHwidth-filename.png]

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -227,8 +227,6 @@ def _get_config(target, options):
         # {{red text|color:red}} -> <span style="color:red">red text</span>
         config['postproc'].append([COLOR_ESCAPED, r'<span style="color:\2">\1</span>'])
 
-
-
         # Custom css
         fonts = options.pop('font', 'sans-serif')
         css = CSS % {'font': fonts, 'table_head_bg': TABLE_HEAD_BG}

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -147,9 +147,9 @@ def get_markup_for_day(day, with_text=True, with_tags=True, categories=None, dat
     if date:
         # Following anchor placeholder will be used as a target for every entry reference
         # mentioning this entry's date. In postprocessing it will be replaced by relevant HTML tag.
-        date_anchor = 'DATE_ANCHOR_PLACEHOLDER_%s' % day.date.strftime('%Y-%m-%d')
+        date_anchor = 'DATE_ANCHOR_PLACEHOLDER_{:%Y-%m-%d}'.format(day.date)
 
-        export_string += '= %s %s =\n\n' % (date_anchor, date)
+        export_string += '= {anchor} {date} =\n\n'.format(anchor=date_anchor, date=date)
 
     # Add text
     if with_text:

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -50,7 +50,6 @@ COLOR_ESCAPED = r'XBEGINCOLORX(.*?)XSEPARATORX(.*?)XENDCOLORX'
 TABLE_HEAD_BG = '#aaa'
 
 CHARSET_UTF8 = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />'
-PRINT_FUNCTION = '<script></script>'
 
 CSS = """\
 <style type="text/css">
@@ -246,6 +245,15 @@ def _get_config(target, options):
         config['preproc'].append([r'\[(?P<date>\d{4}-\d{2}-\d{2})\]',
                                   r'[\g<date> #\g<date>]'])
 
+        # Custom css
+        fonts = options.pop('font', 'sans-serif')
+        css = CSS % {'font': fonts, 'table_head_bg': TABLE_HEAD_BG}
+        config['postproc'].append([r'</head>', css + '</head>'])
+
+        # MathJax
+        if options.pop('add_mathjax'):
+            config['postproc'].append([r'</body>', MATHJAX + '</body>'])
+
     elif target == 'tex':
         config['encoding'] = 'utf8'
         config['preproc'].append(['€', 'Euro'])
@@ -279,6 +287,7 @@ def _get_config(target, options):
         config['preproc'].append([r'\\\[\s*(.+?)\s*\\\]', r"BEGINEQUATION''\1''ENDEQUATION"])
         config['preproc'].append([r'\$\$\s*(.+?)\s*\$\$', r"BEGINEQUATION''\1''ENDEQUATION"])
         config['postproc'].append([r'BEGINEQUATION(.+)ENDEQUATION', r'$$\1$$'])
+
         config['preproc'].append([r'\\\(\s*(.+?)\s*\\\)', r"BEGINMATH''\1''ENDMATH"])
         config['postproc'].append([r'BEGINMATH(.+)ENDMATH', r'$\1$'])
 
@@ -293,6 +302,7 @@ def _get_config(target, options):
 
         config['postproc'].append([COLOR_ESCAPED, r'\\textcolor{\2}{\1}'])
 
+        # Remove day anchor placeholders
         config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
 
         # Links to entry references are not supported in TeX export - we rewrite them here.
@@ -300,6 +310,7 @@ def _get_config(target, options):
                                   r'\g<name> (\g<date>)'])
 
     elif target == 'txt':
+        # Remove day anchor placeholders
         config['preproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2}) ', r''])
 
         # Line breaks
@@ -318,18 +329,6 @@ def _get_config(target, options):
 
     # Disable colors for all other targets.
     config['postproc'].append([COLOR_ESCAPED, r'\1'])
-
-    # MathJax
-    if options.pop('add_mathjax'):
-        config['postproc'].append([r'</body>', MATHJAX + '</body>'])
-
-    config['postproc'].append([r'</body>', PRINT_FUNCTION + '</body>'])  # TODO: remove
-
-    # Custom css
-    fonts = options.pop('font', 'sans-serif')
-    if 'html' in target:  # TODO: it seems that 'html' target is never used
-        css = CSS % {'font': fonts, 'table_head_bg': TABLE_HEAD_BG}
-        config['postproc'].append([r'</head>', css + '</head>'])
 
     config.update(options)
 

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -187,8 +187,6 @@ def get_markup_for_day(day, with_text=True, with_tags=True, categories=None, dat
 
 
 def _get_config(target, options):
-    is_exporting_to_file = options.get('export_to_file', False)
-
     # Set the configuration on the 'config' dict.
     config = txt2tags.ConfigMaster()._get_defaults()
 
@@ -231,11 +229,10 @@ def _get_config(target, options):
         config['postproc'].append([COLOR_ESCAPED, r'<span style="color:\2">\1</span>'])
 
         # Entry references
-        if is_exporting_to_file:
-            # `get_markup_for_day` will generate placeholders which we need to override in order to create
-            # anchor targets for entry reference links to point to.
-            config['postproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2})',
-                                      r'<span id="\g<date>"></span>'])
+        # `get_markup_for_day` will generate placeholders which we need to override in order to create
+        # anchor targets for entry reference links to point to.
+        config['postproc'].append([r'DATE_ANCHOR_PLACEHOLDER_(?P<date>\d{4}-\d{2}-\d{2})',
+                                  r'<span id="\g<date>"></span>'])
 
         # txt2tags will generate links to the named entry references because they share common bracket
         # notation used by the URIs. We just need to add our internal schema to make it a proper URI.
@@ -325,11 +322,11 @@ def _get_config(target, options):
     if options.pop('add_mathjax'):
         config['postproc'].append([r'</body>', MATHJAX + '</body>'])
 
-    config['postproc'].append([r'</body>', PRINT_FUNCTION + '</body>'])
+    config['postproc'].append([r'</body>', PRINT_FUNCTION + '</body>'])  # TODO: remove
 
     # Custom css
     fonts = options.pop('font', 'sans-serif')
-    if 'html' in target:
+    if 'html' in target:  # TODO: it seems that 'html' target is never used
         css = CSS % {'font': fonts, 'table_head_bg': TABLE_HEAD_BG}
         config['postproc'].append([r'</head>', css + '</head>'])
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,7 +1,9 @@
+import datetime
 import sys
 
 import pytest
 
+from rednotebook.data import Day, Month
 from rednotebook.util.markup import convert_to_pango, convert_from_pango, \
     convert, _convert_paths, get_markup_for_day
 
@@ -156,8 +158,6 @@ class TestGetXHtmlExportConfig:
         assert expected in document
 
     def test_day_fragment_anchor_element(self, process):
-        from rednotebook.data import Day, Month
-        import datetime
         date = datetime.date(2019, 10, 21)
         day = Day(Month(date.year, date.month), date.day)
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -59,18 +59,6 @@ def test_absolute_path_conversion(tmp_path):
         assert path == _convert_paths(path, tmp_path)
 
 
-def test_html_export_contains_day_fragment_reference_element(tmp_path):
-    from rednotebook.data import Day, Month
-    import datetime
-    date = datetime.date(2019, 10, 21)
-    day = Day(Month(date.year, date.month), date.day)
-
-    txt2tag_markup = get_markup_for_day(day, date=date.strftime("%d-%m-%Y"))
-    html_document = convert(txt2tag_markup, 'xhtml', tmp_path, options={'export_to_file': True})
-
-    assert r'id="{:%Y-%m-%d}"'.format(date) in html_document
-
-
 class TestGetXHtmlExportConfig:
     @staticmethod
     @pytest.fixture
@@ -166,6 +154,17 @@ class TestGetXHtmlExportConfig:
     def test_entry_reference_links(self, markup, expected, process):
         document = process(markup)
         assert expected in document
+
+    def test_day_fragment_anchor_element(self, process):
+        from rednotebook.data import Day, Month
+        import datetime
+        date = datetime.date(2019, 10, 21)
+        day = Day(Month(date.year, date.month), date.day)
+
+        markup = get_markup_for_day(day, 'xhtml', date=date.strftime("%d-%m-%Y"))
+        document = process(markup)
+
+        assert r'<span id="{:%Y-%m-%d}"></span>'.format(date) in document
 
     def test_mathjax(self, process):
         document = process('$$x^3$$')
@@ -286,10 +285,6 @@ class TestGetTexExportConfig:
         document = process("#tag")
         assert r'\index{tag}' in "".join(document)
 
-    def test_date_anchor_removal(self, process):
-        document = process("DATE_ANCHOR_PLACEHOLDER_2019-10-30 ")
-        assert r'DATE_ANCHOR_PLACEHOLDER_2019-10-30 ' not in document
-
     @pytest.mark.parametrize("markup,expected", [
         ('This is a [named reference 2019-08-01]', 'This is a named reference (2019-08-01)'),
         ('Today is 2019-08-01 - a wonderful day', 'Today is 2019-08-01 - a wonderful day'),
@@ -332,10 +327,6 @@ class TestGetPlainTextExportConfig:
     def test_images_width_resize(self, markup, expected, process):
         document = process(markup)
         assert expected in document
-
-    def test_date_anchor_removal(self, process):
-        document = process("DATE_ANCHOR_PLACEHOLDER_2019-10-30 ")
-        assert r'DATE_ANCHOR_PLACEHOLDER_2019-10-30 ' not in document
 
     @pytest.mark.parametrize("markup,expected", [
         ('This is a [named reference 2019-08-01]', 'This is a named reference (2019-08-01)'),

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -64,7 +64,7 @@ class TestGetXHtmlExportConfig:
     @pytest.fixture
     def process(tmp_path):
         def process(markup):
-            html_document = convert(markup, 'xhtml', tmp_path, options={'export_to_file': True})
+            html_document = convert(markup, 'xhtml', tmp_path)
             return html_document.split('\n')
         return process
 
@@ -176,7 +176,7 @@ class TestGetTexExportConfig:
     @pytest.fixture
     def process(tmp_path):
         def process(markup):
-            html_document = convert(markup, 'tex', tmp_path, options={'export_to_file': True})
+            html_document = convert(markup, 'tex', tmp_path)
             return html_document.split('\n')
         return process
 
@@ -299,7 +299,7 @@ class TestGetPlainTextExportConfig:
     @pytest.fixture
     def process(tmp_path):
         def process(markup):
-            html_document = convert(markup, 'txt', tmp_path, options={'export_to_file': True})
+            html_document = convert(markup, 'txt', tmp_path)
             return html_document.split('\n')
         return process
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,4 +1,4 @@
-import re
+import sys
 
 import pytest
 
@@ -31,63 +31,6 @@ def test_pango(t2t_markup, expected):
     # preserve the encoding
     if '&amp;' not in t2t_markup:
         assert convert_from_pango(pango) == t2t_markup
-
-
-@pytest.mark.parametrize("markup,expected", [
-    ('[""/image"".png?50]',
-     '<img align="middle" width="50" src="/image.png" border="0" alt=""/>'),
-    ('[""/image"".jpg]',
-     '<img align="middle" src="/image.jpg" border="0" alt=""/>'),
-    ('[""file:///image"".png?10]',
-     '<img align="middle" width="10" src="file:///image.png" border="0" alt=""/>'),
-    ('[""file:///image"".jpg]', '<img align="middle" '
-                                'src="file:///image.jpg" border="0" '
-                                'alt=""/>'),
-])
-def test_images(markup, expected, tmp_path):
-    html = convert(markup, 'xhtml', tmp_path)
-    location = re.search(r'(<img.*?>)', html).group(1)
-    assert location == expected
-
-
-@pytest.mark.parametrize("markup,expected_xhtml", [
-    ('Simple [named reference 2019-08-01]', 'Simple <a href="#2019-08-01">named reference</a>'),
-    ('An inline 2019-08-01 date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
-    ('2019-10-20 is first', '<a href="#2019-10-20">2019-10-20</a> is first'),
-    ('(2019-10-20)', '(<a href="#2019-10-20">2019-10-20</a>)')
-])
-def test_reference_links_in_xhtml(markup, expected_xhtml, tmp_path):
-    document = convert(markup, 'xhtml', tmp_path)
-    assert expected_xhtml in document
-
-
-@pytest.mark.parametrize("markup,expected_xhtml", [
-    ('Simple [named reference 2019-08-01]', 'Simple <a href="#2019-08-01">named reference</a>'),
-    ('An inline 2019-08-01 date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
-])
-def test_reference_links_are_present_in_html_export(markup, expected_xhtml, tmp_path):
-    document = convert(markup, 'xhtml', tmp_path, options={'export_to_file': True})
-    assert expected_xhtml in document
-
-
-@pytest.mark.parametrize("markup,expected_tex", [
-    ('This is a [named reference 2019-08-01]', 'This is a named reference (2019-08-01)'),
-    ('Today is 2019-08-01 - a wonderful day', 'Today is 2019-08-01 - a wonderful day'),
-])
-def test_reference_links_in_tex(markup, expected_tex, tmp_path):
-    document = convert(markup, 'tex', tmp_path)
-    assert expected_tex in document
-
-
-@pytest.mark.parametrize("markup,expected", [
-    ('[""/image"".png?50]', '\\includegraphics[width=50px]{"/image".png}'),
-    ('[""/image"".jpg]', '\\includegraphics{"/image".jpg}'),
-    ('[""file:///image"".png?10]', '\\includegraphics[width=10px]{"/image".png}'),
-    ('[""file:///image"".jpg]', '\\includegraphics{"/image".jpg}'),
-])
-def test_images_latex(markup, expected, tmp_path):
-    latex = convert(markup, 'tex', tmp_path)
-    assert expected in latex
 
 
 def test_relative_path_conversion(tmp_path):
@@ -126,3 +69,278 @@ def test_html_export_contains_day_fragment_reference_element(tmp_path):
     html_document = convert(txt2tag_markup, 'xhtml', tmp_path, options={'export_to_file': True})
 
     assert r'id="{:%Y-%m-%d}"'.format(date) in html_document
+
+
+class TestGetXHtmlExportConfig:
+    @staticmethod
+    @pytest.fixture
+    def process(tmp_path):
+        def process(markup):
+            html_document = convert(markup, 'xhtml', tmp_path, options={'export_to_file': True})
+            return html_document.split('\n')
+        return process
+
+    def test_encoding(self, process):
+        document = process("Content")
+        assert '      encoding="UTF-8"' in document
+
+    def test_firefox_encoding_bug(self, process):
+        document = process("Content")
+        assert '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" />' in document
+
+    def test_toc(self, process):
+        document = process("Content")
+        assert '<div class="toc">' not in document
+
+    def test_css_sugar(self, process):
+        document = process("Content")
+        assert '<div class="body" id="body">' in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('content \\\\ ', 'content <br />'),
+        ('content\\\\', 'content<br />'),
+        ('content\\\\ ', 'content<br />'),
+    ])
+    def test_line_break_escaping(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('#TAG', r'<span style="color:red">#TAG</span>'),
+        ('Numeric #3tag', r'Numeric <span style="color:red">#3tag</span>'),
+        ('Just #34 numbers', r'Just #34 numbers'),
+    ])
+    def test_hashtags(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('{Sky|color:blue}', r'<span style="color:blue">Sky</span>'),
+        ('{Red|color:#FF0000} firetruck', r'<span style="color:#FF0000">Red</span> firetruck'),
+    ])
+    def test_colors(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('[""/image"".png?50]',
+         '<img align="middle" width="50" src="/image.png" border="0" alt=""/>'),
+        ('[""/image"".jpg?50]',
+         '<img align="middle" width="50" src="/image.jpg" border="0" alt=""/>'),
+        ('[""/image"".jpeg?50]',
+         '<img align="middle" width="50" src="/image.jpeg" border="0" alt=""/>'),
+        ('[""/image"".gif?50]',
+         '<img align="middle" width="50" src="/image.gif" border="0" alt=""/>'),
+        ('[""/image"".eps?50]',
+         '<img align="middle" width="50" src="/image.eps" border="0" alt=""/>'),
+        ('[""/image"".bmp?50]',
+         '<img align="middle" width="50" src="/image.bmp" border="0" alt=""/>'),
+        ('[""/image"".svg?50]',
+         '<img align="middle" width="50" src="/image.svg" border="0" alt=""/>'),
+    ])
+    def test_images_resize_allowed_extensions(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('[""/image"".png?50]',
+         '<img align="middle" width="50" src="/image.png" border="0" alt=""/>'),
+        ('[""/image"".jpg]',
+         '<img align="middle" src="/image.jpg" border="0" alt=""/>'),
+        ('[""file:///image"".png?10]',
+         '<img align="middle" width="10" src="file:///image.png" border="0" alt=""/>'),
+        ('[""file:///image"".jpg]', '<img align="middle" '
+                                    'src="file:///image.jpg" border="0" '
+                                    'alt=""/>'),
+    ])
+    def test_images_width_resize(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('Simple [named reference 2019-08-01]', 'Simple <a href="#2019-08-01">named reference</a>'),
+        ('An inline 2019-08-01 date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
+        ('2019-10-20 is first', '<a href="#2019-10-20">2019-10-20</a> is first'),
+        ('(2019-10-20)', '(<a href="#2019-10-20">2019-10-20</a>)')
+    ])
+    def test_entry_reference_links(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    def test_mathjax(self, process):
+        document = process('$$x^3$$')
+        assert r'<script type="text/x-mathjax-config">' in document
+
+
+class TestGetTexExportConfig:
+    @staticmethod
+    @pytest.fixture
+    def process(tmp_path):
+        def process(markup):
+            html_document = convert(markup, 'tex', tmp_path, options={'export_to_file': True})
+            return html_document.split('\n')
+        return process
+
+    def test_encoding(self, process):
+        document = process("Content")
+        assert r'\usepackage[utf8]{inputenc}  % char encoding' in document
+
+    def test_euro_replacement(self, process):
+        document = process("€")
+        assert 'Euro' in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        (r'[""file/path"".png]', r'\includegraphics{"file/path".png}'),
+    ])
+    def test_path_escape(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific")
+    def test_image_scheme_fix_win32(self, process):
+        document = process('[""file:///image"".png]')
+        assert r'\includegraphics{"image".png}' in document
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-specific")
+    def test_image_scheme_fix_posix(self, process):
+        document = process('[""file://image"".png]')
+        assert r'\includegraphics{"image".png}' in document
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific")
+    def test_file_scheme_fix_win32(self, process):
+        document = process('[file.txt file:///path/to/text/file.txt]')
+        assert r'\htmladdnormallink{file.txt}{run:path/to/text/file.txt}' in document
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-specific")
+    def test_file_scheme_fix_posix(self, process):
+        document = process('[file.txt file://path/to/text/file.txt]')
+        assert r'\htmladdnormallink{file.txt}{run:path/to/text/file.txt}' in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('content \\\\ ', 'content \\\\'),
+        ('content\\\\', 'content\\\\'),
+        ('content\\\\ ', 'content\\\\'),
+    ])
+    def test_line_break_escaping(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('#TAG', r'\textcolor{red}{\#TAG\index{TAG}}'),
+        ('Numeric #3tag', r'Numeric \textcolor{red}{\#3tag\index{3tag}}'),
+        ('Just #34 numbers', r'Just \#34 numbers'),
+        ('#include <iostream>', r'\#include $<$iostream$>$'),
+        # TODO: ('#define FOO BAR', r'\#define FOO BAR'),
+        ('Blue: #0000FF', r'Blue: \#0000FF'),
+    ])
+    def test_hashtags(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('[""image"".png?50]', '\\includegraphics[width=50px]{"image".png}'),
+        ('[""image"".jpg]', '\\includegraphics{"image".jpg}'),
+    ])
+    def test_images_width_resize(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        (r'\[f(x) = x^2\]', '$$f(x) = x^2$$'),
+        (r'$$f(x) = x^2$$', '$$f(x) = x^2$$'),
+    ])
+    def test_latex_equation_escape_display_mode(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        (r'\(f(x) = x^2\)', '$f(x) = x^2$'),
+    ])
+    def test_latex_equation_escape_inline_mode(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        (r'„content”', '"content"'),
+        (r'”content“', '"content"'),
+    ])
+    def test_quotation_mark_replacement(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('{Sky|color:blue}', r'\textcolor{blue}{Sky}'),
+        ('{Red|color:#FF0000} firetruck', r'\textcolor{\#FF0000}{Red} firetruck'),
+    ])
+    def test_colors(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    def test_index_generation(self, process):
+        document = process("content")
+        assert r'\usepackage{makeidx}  % user defined' in document
+        assert r'\makeindex' in document
+        assert r'\printindex' in document
+
+    def test_tags_are_collected_for_index_generation(self, process):
+        document = process("#tag")
+        assert r'\index{tag}' in "".join(document)
+
+    def test_date_anchor_removal(self, process):
+        document = process("DATE_ANCHOR_PLACEHOLDER_2019-10-30 ")
+        assert r'DATE_ANCHOR_PLACEHOLDER_2019-10-30 ' not in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('This is a [named reference 2019-08-01]', 'This is a named reference (2019-08-01)'),
+        ('Today is 2019-08-01 - a wonderful day', 'Today is 2019-08-01 - a wonderful day'),
+    ])
+    def test_entry_reference_links(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+
+class TestGetPlainTextExportConfig:
+    @staticmethod
+    @pytest.fixture
+    def process(tmp_path):
+        def process(markup):
+            html_document = convert(markup, 'txt', tmp_path, options={'export_to_file': True})
+            return html_document.split('\n')
+        return process
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('content \\\\ ', 'content '),
+        ('content\\\\', 'content'),
+        ('content\\\\ ', 'content'),
+    ])
+    def test_line_break_escaping(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('{Sky|color:blue}', r'Sky'),
+        ('{Red|color:#FF0000} firetruck', r'Red firetruck'),
+    ])
+    def test_colors(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('[image.png?50]', '[image.png?50]'),
+        ('[image.jpg]', '[image.jpg]'),
+    ])
+    def test_images_width_resize(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document
+
+    def test_date_anchor_removal(self, process):
+        document = process("DATE_ANCHOR_PLACEHOLDER_2019-10-30 ")
+        assert r'DATE_ANCHOR_PLACEHOLDER_2019-10-30 ' not in document
+
+    @pytest.mark.parametrize("markup,expected", [
+        ('This is a [named reference 2019-08-01]', 'This is a named reference (2019-08-01)'),
+        ('Today is 2019-08-01 - a wonderful day', 'Today is 2019-08-01 - a wonderful day'),
+    ])
+    def test_entry_reference_links(self, markup, expected, process):
+        document = process(markup)
+        assert expected in document

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -96,10 +96,10 @@ def test_relative_path_conversion(tmp_path):
     tmp_path_uri = 'file://' + str(tmp_path)
 
     rel_paths = [
-        ('[""file://rel"".jpg]', '[""%s/rel"".jpg]' % tmp_path_uri),
-        ('[""rel"".jpg]', '[""%s/rel"".jpg]' % tmp_path_uri),
-        ('[rel.pdf ""file://rel.pdf""]', '[rel.pdf ""%s/rel.pdf""]' % tmp_path_uri),
-        ('[rel.pdf ""rel.pdf""]', '[rel.pdf ""%s/rel.pdf""]' % tmp_path_uri)
+        ('[""file://rel"".jpg]', '[""{}/rel"".jpg]'.format(tmp_path_uri)),
+        ('[""rel"".jpg]', '[""{}/rel"".jpg]'.format(tmp_path_uri)),
+        ('[rel.pdf ""file://rel.pdf""]', '[rel.pdf ""{}/rel.pdf""]'.format(tmp_path_uri)),
+        ('[rel.pdf ""rel.pdf""]', '[rel.pdf ""{}/rel.pdf""]'.format(tmp_path_uri))
     ]
 
     for markup, expected in rel_paths:
@@ -108,8 +108,8 @@ def test_relative_path_conversion(tmp_path):
 
 def test_absolute_path_conversion(tmp_path):
     abs_paths = [
-        '[""file:///abs"".jpg]', '[""%s/aha 1"".jpg]' % tmp_path,
-        '[abs.pdf ""file:///abs.pdf""]', '[abs.pdf ""%s/abs.pdf""]' % tmp_path,
+        '[""file:///abs"".jpg]', '[""{}/aha 1"".jpg]'.format(tmp_path),
+        '[abs.pdf ""file:///abs.pdf""]', '[abs.pdf ""{}/abs.pdf""]'.format(tmp_path),
         'www.google.com', 'www.google.com/page.php']
 
     for path in abs_paths:
@@ -118,11 +118,11 @@ def test_absolute_path_conversion(tmp_path):
 
 def test_html_export_contains_day_fragment_reference_element(tmp_path):
     from rednotebook.data import Day, Month
-    from datetime import date
-    date = date(2019, 10, 21)
+    import datetime
+    date = datetime.date(2019, 10, 21)
     day = Day(Month(date.year, date.month), date.day)
 
     txt2tag_markup = get_markup_for_day(day, date=date.strftime("%d-%m-%Y"))
     html_document = convert(txt2tag_markup, 'xhtml', tmp_path, options={'export_to_file': True})
 
-    assert (r'id="%s"' % date.strftime("%Y-%m-%d")) in html_document
+    assert r'id="{:%Y-%m-%d}"'.format(date) in html_document


### PR DESCRIPTION
By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
* Generate clickable entry reference links in (multi-day) HTML exports