### PR TITLE
Option for controlling number of displayed tags

### DIFF
--- a/rednotebook/configuration.py
+++ b/rednotebook/configuration.py
@@ -53,7 +53,7 @@ class Config(dict):
         'mainFrameY': None,
         'leftDividerPosition': 260,
         'rightDividerPosition': None,
-        'tagDisplayLimit': 1000,
+        'cloudMaxTags': 1000,
     }
 
     obsolete_keys = {

--- a/rednotebook/configuration.py
+++ b/rednotebook/configuration.py
@@ -53,7 +53,7 @@ class Config(dict):
         'mainFrameY': None,
         'leftDividerPosition': 260,
         'rightDividerPosition': None,
-        'tagDisplayLimit': 20,
+        'tagDisplayLimit': 1000,
     }
 
     obsolete_keys = {

--- a/rednotebook/configuration.py
+++ b/rednotebook/configuration.py
@@ -53,6 +53,7 @@ class Config(dict):
         'mainFrameY': None,
         'leftDividerPosition': 260,
         'rightDividerPosition': None,
+        'tagDisplayLimit': 20,
     }
 
     obsolete_keys = {

--- a/rednotebook/gui/clouds.py
+++ b/rednotebook/gui/clouds.py
@@ -156,12 +156,19 @@ class Cloud(browser.HtmlView):
         word, freq = word_and_freq
         return locale.strxfrm(word)
 
+    @staticmethod
+    def _frequency(word_and_freq):
+        word, freq = word_and_freq
+        return freq
+
     def _get_tags_for_cloud(self, tag_count_dict, ignores):
         tags_and_frequencies = [(tag, freq) for (tag, freq) in tag_count_dict
                                 if not any(pattern.match(tag) for pattern in ignores)]
-        tags_and_frequencies.sort(key=self._get_collated_word)
+
+        # Sort by the frequency of occurrence
+        tags_and_frequencies.sort(key=self._frequency, reverse=True)
         tag_display_limit = self.journal.config.read('tagDisplayLimit')
-        return tags_and_frequencies[-tag_display_limit:]
+        return tags_and_frequencies[:tag_display_limit]
 
     def _get_words_for_cloud(self, word_count_dict, ignores, includes):
         # filter short words
@@ -171,13 +178,9 @@ class Cloud(browser.HtmlView):
                  # filter words in ignore_list
                  any(pattern.match(word) for pattern in ignores)]
 
-        def frequency(word_and_freq):
-            (word, freq) = word_and_freq
-            return freq
-
         # only take the longest words. If there are less words than n,
         # len(words) words are returned
-        words.sort(key=frequency)
+        words.sort(key=self._frequency)
         words = words[-CLOUD_WORDS:]
         words.sort(key=self._get_collated_word)
         return words

--- a/rednotebook/gui/clouds.py
+++ b/rednotebook/gui/clouds.py
@@ -162,12 +162,15 @@ class Cloud(browser.HtmlView):
         return freq
 
     def _get_tags_for_cloud(self, tag_count_dict, ignores):
+        tag_display_limit = self.journal.config.read('tagDisplayLimit')
+        if tag_display_limit == 0:
+            return []
+
         tags_and_frequencies = [(tag, freq) for (tag, freq) in tag_count_dict
                                 if not any(pattern.match(tag) for pattern in ignores)]
 
         # Sort by the frequency of occurrence
         tags_and_frequencies.sort(key=self._frequency, reverse=True)
-        tag_display_limit = self.journal.config.read('tagDisplayLimit')
         return tags_and_frequencies[:tag_display_limit]
 
     def _get_words_for_cloud(self, word_count_dict, ignores, includes):

--- a/rednotebook/gui/clouds.py
+++ b/rednotebook/gui/clouds.py
@@ -162,7 +162,7 @@ class Cloud(browser.HtmlView):
         return freq
 
     def _get_tags_for_cloud(self, tag_count_dict, ignores):
-        tag_display_limit = self.journal.config.read('tagDisplayLimit')
+        tag_display_limit = self.journal.config.read('cloudMaxTags')
         if tag_display_limit == 0:
             return []
 

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -116,6 +116,25 @@ class TextOption(Option):
         return self.entry.get_text()
 
 
+class IntegerOption(Option):
+    def __init__(self, text, option_name, default=0, min_value=0, max_value=100, increment=1, **kwargs):
+        Option.__init__(self, text, option_name, **kwargs)
+
+        value = Option.config.read(option_name, default)
+        value = int(value)
+
+        self.spin_button = Gtk.SpinButton()
+        adjustment = Gtk.Adjustment(value, min_value, max_value, increment, 10, 0)
+        self.spin_button.set_adjustment(adjustment)
+        self.spin_button.set_numeric(True)
+        self.spin_button.set_update_policy(Gtk.SpinButtonUpdatePolicy.IF_VALID)
+
+        self.pack_start(self.spin_button, True, True, 0)
+
+    def get_value(self):
+        return self.spin_button.get_value_as_int()
+
+
 class ComboBoxOption(Option):
     def __init__(self, text, name, entries, tooltip=''):
         Option.__init__(self, text, name, tooltip=tooltip)
@@ -299,6 +318,8 @@ class OptionsManager:
                 _('Date format'), 'exportDateFormat',
                 tooltip=_('Used for dates in titlebar and exports.')
                 ),
+            IntegerOption(_('Tag display limit'), 'tagDisplayLimit',
+                          tooltip=_('Maximum number of tags displayed in the cloud')),
             TextOption(_('Exclude from cloud'), 'cloudIgnoreList',
                        tooltip=_('Do not show these comma separated words and #tags in the clouds')),
             TextOption(_('Include small words in cloud'), 'cloudIncludeList',

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -117,7 +117,7 @@ class TextOption(Option):
 
 
 class IntegerOption(Option):
-    def __init__(self, text, option_name, default=0, min_value=0, max_value=100, increment=1, **kwargs):
+    def __init__(self, text, option_name, default=0, min_value=0, max_value=1000, increment=1, **kwargs):
         Option.__init__(self, text, option_name, **kwargs)
 
         value = Option.config.read(option_name, default)

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -318,7 +318,7 @@ class OptionsManager:
                 _('Date format'), 'exportDateFormat',
                 tooltip=_('Used for dates in titlebar and exports.')
                 ),
-            IntegerOption(_('Tag display limit'), 'tagDisplayLimit',
+            IntegerOption(_('Tags in cloud'), 'cloudMaxTags',
                           tooltip=_('Maximum number of tags displayed in the cloud')),
             TextOption(_('Exclude from cloud'), 'cloudIgnoreList',
                        tooltip=_('Do not show these comma separated words and #tags in the clouds')),

--- a/rednotebook/help.py
+++ b/rednotebook/help.py
@@ -216,8 +216,7 @@ lists. If you want to hide words with special characters, you can
 escape them with a backslash: 3\\.50\\?
 
 You can limit the number of displayed words by tweaking the 'Tags in cloud'
-configuration option. If this option is set to 0, all words will be
-displayed.
+configuration option. If this option is set to 0, no tags are displayed.
 
 You can **hide the word cloud** by adding the regular expression .* to
 the blacklist. This will filter out all words.

--- a/rednotebook/help.py
+++ b/rednotebook/help.py
@@ -215,7 +215,7 @@ expressions http://docs.python.org/library/re.html] are allowed in the
 lists. If you want to hide words with special characters, you can
 escape them with a backslash: 3\\.50\\?
 
-You can limit number of displayed words by tweaking 'Tag display limit'
+You can limit the number of displayed words by tweaking the 'Tags in cloud'
 configuration option. If this option is set to 0, all words will be
 displayed.
 

--- a/rednotebook/help.py
+++ b/rednotebook/help.py
@@ -215,6 +215,10 @@ expressions http://docs.python.org/library/re.html] are allowed in the
 lists. If you want to hide words with special characters, you can
 escape them with a backslash: 3\\.50\\?
 
+You can limit number of displayed words by tweaking 'Tag display limit'
+configuration option. If this option is set to 0, all words will be
+displayed.
+
 You can **hide the word cloud** by adding the regular expression .* to
 the blacklist. This will filter out all words.
 


### PR DESCRIPTION
By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
* Add `IntegerOption` class for handling numeric configuration options
* Allow user to limit hashtags displayed in the cloud on the left by utilizing new 'Tag display limit' configuration option

This implements #385.