### PR TITLE
Fix statistics dialog missing data on consecutive invocations

### DIFF
--- a/rednotebook/util/statistics.py
+++ b/rednotebook/util/statistics.py
@@ -88,6 +88,8 @@ class Statistics:
         self.journal.save_old_day()
         self.days = self.journal.days
 
+        dialog.show_all()
+
         day_store = dialog.day_list.get_model()
         day_store.clear()
         for key, value in self.day_pairs:
@@ -98,6 +100,5 @@ class Statistics:
         for key, value in self.overall_pairs:
             overall_store.append((key, str(value)))
 
-        dialog.show_all()
         dialog.run()
         dialog.hide()


### PR DESCRIPTION
By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
* Fix statistics dialog missing data on consecutive invocations

Something strange is going on with ListStore of TreeView widgets in
statistics window. I am not fluent in GTK enough to investigate the
case alone, but attached change seems to fix #370.