### PR TITLE
Remove support for freestanding entry references

### DIFF
--- a/rednotebook/files/t2t.lang
+++ b/rednotebook/files/t2t.lang
@@ -255,7 +255,7 @@
     </context>
 
     <context id="entry-reference">
-      <match>\[\s*(\d{4}-\d{2}-\d{2})\s*\]</match>
+      <match>\[(\d{4}-\d{2}-\d{2})\]</match>
       <include>
         <context sub-pattern="1" style-ref="entry-reference"/>
       </include>

--- a/rednotebook/files/t2t.lang
+++ b/rednotebook/files/t2t.lang
@@ -254,8 +254,11 @@
       <match>(^|[^\w&amp;#])(#|＃)(?![0-9A-F]{6}|include)(\w*[^\W\d_]+\w*)</match>
     </context>
 
-    <context id="entry-reference" style-ref="entry-reference">
-      <match>(([^#\[])|^)\d{4}-\d{2}-\d{2}</match>
+    <context id="entry-reference">
+      <match>\[\s*(\d{4}-\d{2}-\d{2})\s*\]</match>
+      <include>
+        <context sub-pattern="1" style-ref="entry-reference"/>
+      </include>
     </context>
 
     <context id="named-entry-reference">

--- a/rednotebook/help.py
+++ b/rednotebook/help.py
@@ -171,7 +171,7 @@ your computer. Those can be inserted manually however (``[Home
 == Entry references ==
 
 You can reference days in your journal by simply writing the date in
-YYYY-MM-DD format. A date like 2019-02-14 will be rendered as a clickable
+[YYYY-MM-DD] format. A date like [2019-02-14] will be rendered as a clickable
 link in preview mode.
 
 Alternatively, you can name your references. For example,

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -238,10 +238,10 @@ def _get_config(target, options):
             config['preproc'].append([r'\[(?P<name>.+)\s+(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
                                       r'[\g<name> #\g<date>]'])
 
-            # Stand alone dates are converted into named references where the date itself is being
-            # used as a name. For example:
-            # "Today is 2019-10-20" will be converted into "Today is [2019-10-20 notebook:2019-10-20]"
-            config['preproc'].append([r'(?<!#|\[|_)(?P<date>\d{4}-\d{2}-\d{2})',
+            # Convert bracketed dates into named references where the date itself is being used as a name.
+            # For example:
+            # "Today is [2019-10-20]" will be converted into "Today is [2019-10-20 #2019-10-20]"
+            config['preproc'].append([r'\[\s*(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
                                       r'[\g<date> #\g<date>]'])
 
     elif target == 'tex':

--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -241,7 +241,7 @@ def _get_config(target, options):
             # Convert bracketed dates into named references where the date itself is being used as a name.
             # For example:
             # "Today is [2019-10-20]" will be converted into "Today is [2019-10-20 #2019-10-20]"
-            config['preproc'].append([r'\[\s*(?P<date>\d{4}-\d{2}-\d{2})\s*\]',
+            config['preproc'].append([r'\[(?P<date>\d{4}-\d{2}-\d{2})\]',
                                       r'[\g<date> #\g<date>]'])
 
     elif target == 'tex':

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -53,8 +53,7 @@ def test_images(markup, expected, tmp_path):
 @pytest.mark.parametrize("markup,expected_xhtml", [
     ('Simple [named reference 2019-08-01]', 'Simple <a href="#2019-08-01">named reference</a>'),
     ('An inline [2019-08-01] date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
-    ('[2019-10-20] is first', '<a href="#2019-10-20">2019-10-20</a> is first'),
-    ('Spaces [ 2019-10-20  ] are fine too', 'Spaces <a href="#2019-10-20">2019-10-20</a> are fine too')
+    ('[2019-10-20] is first', '<a href="#2019-10-20">2019-10-20</a> is first')
 ])
 def test_reference_links_in_xhtml(markup, expected_xhtml, tmp_path):
     document = convert(markup, 'xhtml', tmp_path)

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -52,9 +52,9 @@ def test_images(markup, expected, tmp_path):
 
 @pytest.mark.parametrize("markup,expected_xhtml", [
     ('Simple [named reference 2019-08-01]', 'Simple <a href="#2019-08-01">named reference</a>'),
-    ('An inline 2019-08-01 date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
-    ('2019-10-20 is first', '<a href="#2019-10-20">2019-10-20</a> is first'),
-    ('(2019-10-20)', '(<a href="#2019-10-20">2019-10-20</a>)')
+    ('An inline [2019-08-01] date', 'An inline <a href="#2019-08-01">2019-08-01</a> date'),
+    ('[2019-10-20] is first', '<a href="#2019-10-20">2019-10-20</a> is first'),
+    ('Spaces [ 2019-10-20  ] are fine too', 'Spaces <a href="#2019-10-20">2019-10-20</a> are fine too')
 ])
 def test_reference_links_in_xhtml(markup, expected_xhtml, tmp_path):
     document = convert(markup, 'xhtml', tmp_path)


### PR DESCRIPTION
The processing needed for them to work interfere with other txt2tags
features. See issue #485.

By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
* Replace freestanding entry reference syntax (`2019-11-06`) with one requiring brackets (`[2019-11-06]`)