### PR TITLE
Random day button

### DIFF
--- a/rednotebook/files/main_window.glade
+++ b/rednotebook/files/main_window.glade
@@ -448,6 +448,19 @@
                         <property name="homogeneous">True</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkToolButton" id="random_day_button">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="no">Go to random day (Alt+R)</property>
+                        <property name="stock_id">gtk-go-random</property>
+                        <signal name="clicked" handler="on_random_day_button_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="homogeneous">True</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -131,6 +131,7 @@ class MainWindow:
         self.back_one_day_button = self.builder.get_object('back_one_day_button')
         self.today_button = self.builder.get_object('today_button')
         self.forward_one_day_button = self.builder.get_object('forward_one_day_button')
+        self.random_day_button = self.builder.get_object('random_day_button')
 
         self.edit_pane = self.builder.get_object('edit_pane')
         self.text_vbox = self.builder.get_object('text_vbox')
@@ -211,6 +212,7 @@ class MainWindow:
             'on_back_one_day_button_clicked': self.on_back_one_day_button_clicked,
             'on_today_button_clicked': self.on_today_button_clicked,
             'on_forward_one_day_button_clicked': self.on_forward_one_day_button_clicked,
+            'on_random_day_button_clicked': self.on_random_day_button_clicked,
 
             'on_preview_button_clicked': self.on_preview_button_clicked,
             'on_edit_button_clicked': self.on_edit_button_clicked,
@@ -270,6 +272,7 @@ class MainWindow:
             (self.back_one_day_button, 'clicked', '<Ctrl>Page_Up'),
             (self.today_button, 'clicked', '<Alt>Home'),
             (self.forward_one_day_button, 'clicked', '<Ctrl>Page_Down'),
+            (self.random_day_button, 'clicked', '<Alt>R')
         ]
         for button, signal, shortcut in shortcuts:
             (keyval, mod) = Gtk.accelerator_parse(shortcut)
@@ -528,6 +531,9 @@ class MainWindow:
 
     def on_forward_one_day_button_clicked(self, widget):
         self.journal.go_to_next_day()
+
+    def on_random_day_button_clicked(self, widget):
+        self.journal.go_to_random_day()
 
     def on_browser_decide_policy(self, webview, decision, decision_type):
         '''

--- a/rednotebook/help.py
+++ b/rednotebook/help.py
@@ -401,6 +401,7 @@ the same directory.
 | Go back one day       | <Ctrl> + PageUp        |
 | Go forward one day    | <Ctrl> + PageDown      |
 | Go to today           | <Alt> + Home (Pos1)    |
+| Go to random day      | <Alt> + R              |
 || Insert               |                        |
 | Insert link           | <Ctrl> + L             |
 | Insert date/time      | <Ctrl> + D             |

--- a/rednotebook/journal.py
+++ b/rednotebook/journal.py
@@ -470,7 +470,7 @@ class Journal:
     def go_to_random_day(self):
         edited_days = self.get_days_in_date_range()
         if edited_days:
-            random_date = edited_days[random.randint(0, len(edited_days))].date
+            random_date = edited_days[random.randint(0, len(edited_days) - 1)].date
         else:
             random_date = self.date
         self.change_date(random_date)

--- a/rednotebook/journal.py
+++ b/rednotebook/journal.py
@@ -25,6 +25,7 @@ import logging
 import os
 import sys
 import time
+import random
 
 
 # Use basic stdout logging before we can initialize logging correctly.
@@ -465,6 +466,14 @@ class Journal:
         if previous_edited_days:
             prev_date = previous_edited_days[-1].date
         self.change_date(prev_date)
+
+    def go_to_random_day(self):
+        edited_days = self.get_days_in_date_range()
+        if edited_days:
+            random_date = edited_days[random.randint(0, len(edited_days))].date
+        else:
+            random_date = self.date
+        self.change_date(random_date)
 
     def show_message(self, msg, title=None, error=False):
         if error and not title:

--- a/rednotebook/templates.py
+++ b/rednotebook/templates.py
@@ -237,6 +237,7 @@ class TemplateManager:
                 self.main_window.back_one_day_button,
                 self.main_window.today_button,
                 self.main_window.forward_one_day_button,
+                self.main_window.random_day_button,
                 self.main_window.search_tree_view,
                 self.main_window.search_box.entry,
                 self.main_window.cloud,


### PR DESCRIPTION
By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

This is a feature I have long wanted RedNotebook to have as I think it is the most convenient way to browse through my past entries for fun.

Summary of the changes in this pull request:
* Added a random day button to jump to random days in the journal. A fun and easy way to read random journal entries.

TODO:
* Add icon and text to button

As of now the random button works fine, though it is invisible and does not have an icon or text. I could not find the part of the code where this is handled. Please let me know where this is implemented and I can do it, if you do not want to accept these changes, please let me know anyway so I can implement them for my personal use. Thanks!