### PR TITLE
Allow on_insert_title to highlight replaced text

### DIFF
--- a/rednotebook/gui/insert_menu.py
+++ b/rednotebook/gui/insert_menu.py
@@ -67,6 +67,16 @@ def get_image(name):
 
 
 def insert_handler(callback_method):
+    """
+    Allows easy creation of text insertion/substitution hooks.
+
+    If wrapped method returns a single string - it will replace selected text and place editor
+    cursor at the end of it.
+
+    Wrapped method may also return triple in (prefix, selected_text, postfix) format.
+    In such case, selected text will be replaced by "{prefix}{selected_text}{postfix}" string with
+    selected_text highlighted in the editor.
+    """
     @functools.wraps(callback_method)
     def insert_handler_wrapper(self, widget, *args, **kwargs):
         editor = self.main_window.day_text_field
@@ -309,7 +319,7 @@ class InsertMenu:
     @insert_handler
     def on_insert_title(self, sel_text, level):
         markup = '=' * level
-        return ' '.join((markup, sel_text, markup))
+        return markup, sel_text, markup
 
     @insert_handler
     def on_insert_line(self, sel_text):


### PR DESCRIPTION
This is a quickfix for #464.

By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
* After inserting title, highlight wrapped text or place cursor in the center of the inserted template.
