### PR TITLE
Copy files to journal

### DIFF
--- a/rednotebook/gui/insert_menu.py
+++ b/rednotebook/gui/insert_menu.py
@@ -254,11 +254,7 @@ class InsertMenu:
                 if copy:
                     filename = self.main_window.journal.add_file(filename)
                     if filename is None:
-                        # TODO: add translations
-                        #self.main_window.journal.show_message(
-                        #    'Could not copy image to journal directory.',
-                        #    error=True)
-
+                        # TODO: manage error
                         return
 
                 base, ext = os.path.splitext(filename)
@@ -303,6 +299,9 @@ class InsertMenu:
             # If required, copy the file and get the relative path
             if copy:
                 filename = self.main_window.journal.add_file(filename)
+                if filename is None:
+                    # TODO: manage error
+                    return
             # Else, get the sanitized absolute path
             else:
                 filename = urls.get_local_url(filename)

--- a/rednotebook/gui/insert_menu.py
+++ b/rednotebook/gui/insert_menu.py
@@ -197,6 +197,11 @@ class InsertMenu:
         if not filesystem.IS_MAC:
             picture_chooser.add_filter(file_filter)
 
+        # Add box for copying the picture to the journal folder
+        copy_checkbutton = Gtk.CheckButton()
+        copy_checkbutton.set_label('Copy to journal folder')
+        copy_checkbutton.set_active(True)  # Set copy as default behaviour
+
         # Add box for inserting image width.
         box = Gtk.HBox()
         box.set_spacing(2)
@@ -207,8 +212,14 @@ class InsertMenu:
         box.pack_start(label, False, False, 0)
         box.pack_start(width_entry, False, False, 0)
         box.pack_start(Gtk.Label(_('pixels')), True, True, 0)
-        box.show_all()
-        picture_chooser.set_extra_widget(box)
+
+        # Add widgets to the window
+        extra_widgets_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        extra_widgets_box.set_spacing(4)
+        extra_widgets_box.pack_start(copy_checkbutton, False, False, 0)
+        extra_widgets_box.pack_start(box, False, False, 0)
+        extra_widgets_box.show_all()
+        picture_chooser.set_extra_widget(extra_widgets_box)
 
         response = picture_chooser.run()
         picture_chooser.hide()
@@ -233,14 +244,30 @@ class InsertMenu:
             if sel_text:
                 sel_text += ' '
 
+            # Check if the image is to be copied
+            copy = copy_checkbutton.get_active()
+
             # iterate through all selected images
             lines = []
             for filename in picture_chooser.get_filenames():
+                # If required, copy the file and get relative filename
+                if copy:
+                    filename = self.main_window.journal.add_file(filename)
+                    if filename is None:
+                        # TODO: add translations
+                        #self.main_window.journal.show_message(
+                        #    'Could not copy image to journal directory.',
+                        #    error=True)
+
+                        return
+
                 base, ext = os.path.splitext(filename)
 
+                # If not copied to the journal dir, get file absolute path
                 # On windows firefox accepts absolute filenames only
                 # with the file:// prefix
-                base = urls.get_local_url(base)
+                if not copy:
+                    base = urls.get_local_url(base)
 
                 lines.append('[{}""{}""{}{}]'.format(sel_text, base, ext, width_text))
 
@@ -252,16 +279,34 @@ class InsertMenu:
         file_chooser = self.main_window.builder.get_object('file_chooser')
         file_chooser.set_current_folder(dirs.last_file_dir)
 
+        # Add box for copying the file to the journal folder
+        copy_checkbutton = Gtk.CheckButton()
+        copy_checkbutton.set_label('Copy to journal folder')
+        copy_checkbutton.set_active(False)  # Set default behaviour
+        copy_checkbutton.show_all()
+        file_chooser.set_extra_widget(copy_checkbutton)
+
         response = file_chooser.run()
         file_chooser.hide()
 
         if response == Gtk.ResponseType.OK:
             folder = file_chooser.get_current_folder()
             # Folder is None if the file was chosen from the "recently used" section.
+
+            # Check if the file is to be copied
+            copy = copy_checkbutton.get_active()
+
             if folder:
                 dirs.last_file_dir = folder
             filename = file_chooser.get_filename()
-            filename = urls.get_local_url(filename)
+
+            # If required, copy the file and get the relative path
+            if copy:
+                filename = self.main_window.journal.add_file(filename)
+            # Else, get the sanitized absolute path
+            else:
+                filename = urls.get_local_url(filename)
+
             sel_text = self.main_window.day_text_field.get_selected_text()
             _, tail = os.path.split(filename)
             # It is always safer to add the "file://" protocol and the ""s

--- a/rednotebook/gui/menu.py
+++ b/rednotebook/gui/menu.py
@@ -187,8 +187,17 @@ class MainMenuBar:
             return
 
         if action == 'saveas':
+            # TODO: read directory name from self.dirs
+            old_media_dir = os.path.join(self.journal.dirs.data_dir, 'media')
+
             self.journal.dirs.data_dir = new_dir
             self.journal.save_to_disk(saveas=True)
+
+            # TODO: read from self.dirs
+            new_media_dir = os.path.join(self.journal.dirs.data_dir, 'media')
+
+            filesystem.copytree(old_media_dir, new_media_dir)
+
         self.journal.open_journal(new_dir)
 
     def on_new_journal_button_activate(self, widget):

--- a/rednotebook/journal.py
+++ b/rednotebook/journal.py
@@ -556,6 +556,56 @@ class Journal:
 
         self.change_date(current_date)
 
+    def add_file(self, src):
+        '''
+        Copy file to journal directory.
+
+        The file is copied to the directory:
+            <journal_path>/media/<year>_<month>
+
+        If a different file with the same name is found in the destination
+        directory, the copy filename is modified to avoid overwritting.
+        See util.filesystem.safecopy() function for details.
+
+        The destination path of the copied relative to the journal
+        directory file is returned.
+        If there is a problem while copying the file, a None vale is
+        returned.
+        '''
+        # TODO: read media folder path from dirs
+        media_dir = os.path.join(self.dirs.data_dir, 'media')
+        try:
+            filesystem.make_directory(media_dir)
+        except OSError as err:
+            logging.error(
+                'Creating journal media directory failed: {}'.format(err))
+            return
+
+        # Create month directory
+        monthmedia_dirname = storage.format_year_and_month(
+            self.date.year, self.date.month)
+        monthmedia_dir = os.path.join(media_dir, monthmedia_dirname)
+        try:
+            filesystem.make_directory(monthmedia_dir)
+        except OSError as err:
+            logging.error('Creating month media directory failed: {}'.format(err))
+            return
+
+        # Copy file to previous dir
+        dst = os.path.join(
+            monthmedia_dir, os.path.basename(src))
+        try:
+            dst = filesystem.safecopy(src, dst)
+        except OSError as err:
+            logging.error(
+                'Copying file to journal directory failed: {}'.format(err))
+            return
+
+        dst_rel = filesystem.get_relative_path(
+            self.dirs.data_dir, dst)
+
+        return dst_rel
+
 
 def main():
     start_time = time.time()

--- a/rednotebook/journal.py
+++ b/rednotebook/journal.py
@@ -347,6 +347,16 @@ class Journal:
 
         self.months = storage.load_all_months_from_disk(data_dir)
 
+        # Create the media folder if it does not exist
+        # TODO: read media folder path from dirs
+        media_dir = os.path.join(self.dirs.data_dir, 'media')
+        try:
+            filesystem.make_directory(media_dir)
+        except OSError as err:
+            logging.error(
+                'Creating journal media directory failed: {}'.format(err))
+            return
+
         # Nothing to save before first day change
         self.load_day(self.actual_date)
 

--- a/rednotebook/storage.py
+++ b/rednotebook/storage.py
@@ -57,7 +57,8 @@ def get_journal_files(data_dir):
             assert month in range(1, 12 + 1)
             path = os.path.join(data_dir, file)
             yield (path, year, month)
-        else:
+        # TODO: read media directory name from dirs
+        elif file != 'media':
             logging.debug('%s is not a valid month filename' % file)
 
 

--- a/rednotebook/util/filesystem.py
+++ b/rednotebook/util/filesystem.py
@@ -257,6 +257,22 @@ def safecopy(src, dst, change_permissions=True):
     return dst
 
 
+def copytree(src, dst, change_permissions=True):
+    '''Copy directory and make it only writable and readable by user.'''
+    shutil.copytree(src, dst)
+
+    if change_permissions:
+        try:
+            # Make files and folders only writable and readable by user
+            for root, dirs, filenames in os.walk(dst):
+                os.chmod(root, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+                for filename in filenames:
+                    os.chmod(os.path.join(root, filename),
+                             stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+
 def get_relative_path(from_dir, to_dir):
     '''
     Try getting the relative path from from_dir to to_dir

--- a/rednotebook/util/filesystem.py
+++ b/rednotebook/util/filesystem.py
@@ -23,6 +23,9 @@ import os
 import platform
 import subprocess
 import sys
+import shutil
+import filecmp
+import stat
 
 ENCODING = sys.getfilesystemencoding() or locale.getlocale()[1] or 'UTF-8'
 LANGUAGE = locale.getdefaultlocale()[0]
@@ -170,6 +173,88 @@ def make_file_with_dir(file, content):
     dir = os.path.dirname(file)
     make_directory(dir)
     make_file(file, content)
+
+
+def _safecopy_filename_generator(filename, marker='-'):
+    '''Returns a generator that yields filenames with a counter.
+
+    This counter is placed before the file extension, and incremented with
+    every iteration.
+
+    For example:
+
+        f1 = increment_filename('myimage.jpeg')
+        f1.next() # myimage.jpeg
+        f1.next() # myimage-2.jpeg
+        f1.next() # myimage-3.jpeg
+
+    Adapted from: http://alexwlchan.net/2015/06/safer-file-copying/
+
+    '''
+    # First we split the filename into the base and the extension
+    base, fileext = os.path.splitext(filename)
+
+    # The counter is just an integer, so we can increment it indefinitely.
+    value = 0
+    while True:
+        if value == 0:
+            value += 1
+            yield filename
+        value += 1
+        yield '{}{}{}{}'.format(base, marker, value, fileext)
+
+
+def safecopy(src, dst, change_permissions=True):
+    '''Copy a file from path src to path dst without overwriting.
+
+    If a file already exists at dst, it will not be overwritten. Instead:
+
+     * If it is the same as the source file, nothing will be done.
+     * If it is different to the source file, a new unused name for the
+       copy will be picked.
+
+    Returns the path to the copied file.
+
+    Adapted from: http://alexwlchan.net/2015/06/safer-file-copying/
+
+    '''
+    if not os.path.exists(src):
+        raise ValueError('Source file does not exist: {}'.format(src))
+
+    # Start the filename generator
+    dst_gen = _safecopy_filename_generator(dst)
+
+    # Iterate over different destination filenames until it works
+    copied = False
+    while not copied:
+        # Generate next destination filename
+        dst = next(dst_gen)
+
+        # Check if there is a file at the destination location
+        if os.path.exists(dst):
+
+            # If the namesake is the same as the source file, then we
+            # don't need to do anything else.
+            if filecmp.cmp(src, dst):
+                copied = True
+
+        else:
+            # If there is no file at the destination, attempt to write
+            # to it.
+            shutil.copy(src, dst)
+            copied = True
+
+            logging.debug(
+                'Copied file from {} to {}.'.format(src, dst))
+
+    # Make file only readable and writable by user
+    if change_permissions:
+        try:
+            os.chmod(dst, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+    return dst
 
 
 def get_relative_path(from_dir, to_dir):


### PR DESCRIPTION
Added support for copying files into the journal directory.

This closes #163.

I have added the method `add_file()` to the `Journal` class, following [this comment](https://github.com/jendrikseipp/rednotebook/issues/163#issuecomment-374143138). This method copies the given file into the directory media/<yyyy>-<mm>/ inside the journal directory, creating the required folders.
I have also changed the `open_journal()` method to create the media directory if it does not exist (I am not sure if this is the best place to do this).

In order to avoid overwriting when copying two different files with the same name, the previous method uses the function `safecopy()`, which has been added to the filesystem module. This function adds a counter to the destination filename if  different file with the same name is found in the destination folder. The new names are generated with the function `_safecopy_filename_generator()`.

In order to copy the files through the GUI, I have modified the `on_insert_pic()` and `on_insert_file()` methods to have an option to copy the files in the `file_chooser` dialog. I have set copy as the default behaviour for pictures but not for the files.

Finally, I have changed the `select_journal()` method in `gui/menu.py` to copy the journal media directory if "Save As" is used. To do so, I have added a new function `copytree()` in `util/filesystem` to copy recursively and change permissions so that only the user can read and write.

Even though the application works as expected with the previous changes, there are some additional ones that are desirable but I have been unable to do:
1. Add the folder name "media" to `Filenames.dirs`.  Right now, the folder name "media" is hardcoded in several places in the code. I think it would be nice to add it to dirs, so that both the folder name "media" and its full path can be retrieved with a  

Summary of the changes in this pull request:
* TODO
