### PR TITLE
fix drag and drop

### DIFF
--- a/rednotebook/gui/editor.py
+++ b/rednotebook/gui/editor.py
@@ -289,7 +289,7 @@ class Editor(GObject.GObject):
         # We do not want the default behaviour
         self.day_text_view.emit_stop_by_name('drag-data-received')
 
-        iter = self.day_text_view.get_iter_at_location(x, y)
+        iter = self.day_text_view.get_iter_at_location(x, y)[1]
 
         def is_pic(uri):
             _, ext = os.path.splitext(uri)


### PR DESCRIPTION
By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```

Summary of the changes in this pull request:
```
Traceback (most recent call last):
  File "rednotebook/rednotebook/gui/editor.py", line 307, in on_drag_data_received
    self.insert('[""{}""{}]\n'.format(uri_without_ext, ext), iter)
  File "rednotebook/rednotebook/gui/editor.py", line 108, in insert
    self.day_text_buffer.insert(iter, text)
  File "/usr/lib64/python3.7/site-packages/gi/overrides/Gtk.py", line 763, in insert
    Gtk.TextBuffer.insert(self, iter, text, length)
TypeError: argument iter: Expected Gtk.TextIter, but got rednotebook.gui.editor._ResultTuple
```
With GTK3, `get_iter_at_location(x, y)` returns a tuple `(bool, iter: Gtk.TextIter)`. Old behavior was for PyGTK2 which returned a Gtk.TextIter.

1. https://lazka.github.io/pgi-docs/Gtk-3.0/classes/TextView.html#Gtk.TextView.get_iter_at_location
2. https://developer.gnome.org/pygtk/stable/class-gtktextview.html#method-gtktextview--get-iter-at-location