### PR TITLE
add missing argument to show in browser

### DIFF
--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -37,7 +37,7 @@ from rednotebook.gui import (
     search,
 )
 from rednotebook.gui.customwidgets import CustomComboBoxEntry, CustomListView
-from rednotebook.gui.exports import ExportAssistant
+from rednotebook.gui.exports import ExportAssistant, HtmlExporter
 from rednotebook.gui.menu import MainMenuBar
 from rednotebook.gui.options import OptionsManager
 from rednotebook.util import dates, filesystem, markup, urls, utils
@@ -454,7 +454,7 @@ class MainWindow:
         else:
             date_format = self.journal.config.read("exportDateFormat")
             date_string = dates.format_date(date_format, self.day.date)
-            markup_string = markup.get_markup_for_day(self.day)
+            markup_string = markup.get_markup_for_day(self.day, HtmlExporter)
             html = self.journal.convert(
                 markup_string,
                 "xhtml",


### PR DESCRIPTION
<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

Summary of the changes in this pull request:
* fixes the "preview in browser" button to actually preview in browser.

the method was definitely missing an argument, but note that I am running from macos, so I might have found this bug through a weird path
