### PR TITLE
Upgrade to mathjax v3

### DIFF
--- a/rednotebook/util/markup.py
+++ b/rednotebook/util/markup.py
@@ -108,7 +108,7 @@ CSS = """\
 
 # MathJax
 FORMULAS_SUPPORTED = True
-MATHJAX_FILE = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"
+MATHJAX_FILE = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"
 
 # Explicitly setting inlineMath: [ ['\\(','\\)'] ] doesn't work.
 # Using defaults:
@@ -116,18 +116,7 @@ MATHJAX_FILE = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"
 #       inlineMath:  [['\(','\)']]
 MATHJAX_DELIMITERS = ["$$", "\\(", "\\)", r"\\[", "\\]"]
 MATHJAX = """\
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({{
-    messageStyle: "none",
-    config: ["MMLorHTML.js"],
-    jax: ["input/TeX","input/MathML","output/HTML-CSS","output/NativeMML"],
-    tex2jax: {{}},
-    extensions: ["tex2jax.js","mml2jax.js","MathMenu.js","MathZoom.js"],
-    TeX: {{
-      extensions: ["AMSmath.js","AMSsymbols.js","noErrors.js","noUndefined.js"]
-    }}
-  }});
-</script>
+<!--MathJax included-->
 <script type="text/javascript" src="{MATHJAX_FILE}"></script>
 """.format(
     **locals()

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -234,7 +234,7 @@ class TestGetXHtmlExportConfig:
 
     def test_mathjax(self, process):
         document = process("$$x^3$$")
-        assert r'<script type="text/x-mathjax-config">' in document
+        assert r"<!--MathJax included-->" in document
 
 
 class TestGetTexExportConfig:


### PR DESCRIPTION
Summary of the changes in this pull request:
* Upgrade to MathJax v3

Improvements:
- Much faster rendering/preview times
- Always loads latest available 3.x.x version of MathJax