### PR TITLE
Repack upstream tarball and remove debian folder.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,9 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: rednotebook
+Files-Excluded: debian
+
+Comment: The following files and folders were removed because
+ debian: Remove upstream debian folder
 
 Files: *
 Copyright: Copyright (C) 2008-2020 Jendrik Seipp <jendrikseipp@gmail.com>

--- a/debian/watch
+++ b/debian/watch
@@ -3,6 +3,7 @@
 # Compulsory line, this is a version 4 file.
 version=4
 
-opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%rednotebook-$1.tar.gz%" \
+opts="repacksuffix=+ds,,dversionmangle=s/\+ds//,repack,compression=gz, \
+  filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%rednotebook-$1.tar.gz%" \
   https://github.com/jendrikseipp/rednotebook/tags \
   (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
Repack upstream tarball and remove 'debian' folder.

Notes.

The Debian project discourages importing upstream original tarballs with a 'debian' folder. Debian prefers all packaging to be done in Debian and be a continuation of when an already included package was removed. They also like a changelog that only details Debian related changes.

For this reason when using 'uscan' to import latest 'rednotebook' releases it will automagically strip out and repack the '.orig' archive. When updating the changelog, this will now mean adding where not automatically done '+ds' after the upstream version number e.g. 2.20+ds-1.
