### PR TITLE
Revert last change to 'copyright' and eliminate whitespace...

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,12 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: rednotebook
+Files-Excluded: debian
+Comment: The following files and folders were removed because
+ debian: Remove upstream debian folder
 
 Files: *
 Copyright: Copyright (C) 2008-2020 Jendrik Seipp <jendrikseipp@gmail.com>
 License: GPL-2+
-
-Files-Excluded: debian
-
-Comment: The following files and folders were removed because
- debian: Remove upstream debian folder
 
 Files: debian/*
 Copyright: Copyright (C) 2008, 2009 Jonathan Wiltshire <debian@jwiltshire.org.uk>


### PR DESCRIPTION
Revert last change to 'copyright' and eliminate whitespace between 'Files-Excluded' and 'Comment'. Lintian warnings all removed and issues with strict rules on uploading into debian mentors fixed.

Note:

This was the last change and 2.20 has now been submitted for inclusion in Debian.
