### PR TITLE
Fix official debian build...

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,9 @@ Rules-Requires-Root: no
 Homepage: https://rednotebook.app
 Vcs-Git: https://github.com/jendrikseipp/rednotebook.git
 Vcs-Browser: https://github.com/jendrikseipp/rednotebook
-Build-Depends: debhelper-compat (= 13)
-Build-Depends-Indep: python3, dh-python
+Build-Depends: debhelper-compat (= 13),
+               python3,
+               dh-python
 
 Package: rednotebook
 Architecture: all


### PR DESCRIPTION
Fix official debian build...

Debians official build servers do not work with python as 'Build-Depends-Indep'. Moved python deps to 'Build-Depends'.