### PR TITLE
Add a "Give Feedback" option in Help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Add a "Give Feedback" button (#551, Rahul Jha).
+
 # 2.21 (2020-12-07)
 * Update MathJax to version 3 (#515, @dgcampea).
 * Fix date references in CEF-based HtmlView (#544, Paweł Żukowski).

--- a/rednotebook/gui/menu.py
+++ b/rednotebook/gui/menu.py
@@ -65,6 +65,7 @@ MENUBAR_XML = """\
         <menuitem action="OnlineHelp"/>
         <menuitem action="Translate"/>
         <menuitem action="ReportBug"/>
+        <menuitem action="GiveFeedback"/>
         <separator/>
         <menuitem action="Info"/>
     </menu>
@@ -257,6 +258,14 @@ class MainMenuBar:
                     _("Fill out a short form about the problem"),
                     self.on_report_bug,
                 ),
+                (
+                    "GiveFeedback",
+                    None,
+                    _("Give Feedback"),
+                    None,
+                    _("How can we improve RedNotebook?"),
+                    self.on_give_feedback,
+                ),
                 ("Info", Gtk.STOCK_ABOUT, None, None, None, self.on_info_activate),
             ]
         )
@@ -408,6 +417,9 @@ class MainMenuBar:
 
     def on_report_bug(self, widget):
         webbrowser.open(info.bug_url)
+
+    def on_give_feedback(self, widget):
+        webbrowser.open(info.discussion_url)
 
     def on_info_activate(self, widget):
         self.info_dialog = self.main_window.builder.get_object("about_dialog")

--- a/rednotebook/info.py
+++ b/rednotebook/info.py
@@ -39,6 +39,7 @@ translation_url = "https://translations.launchpad.net/rednotebook/"
 bug_url = "https://github.com/jendrikseipp/rednotebook/issues"
 version_url = "https://raw.githubusercontent.com/jendrikseipp/rednotebook/master/rednotebook/info.py"
 contributors_url = "https://github.com/jendrikseipp/rednotebook/graphs/contributors"
+discussion_url = "https://github.com/jendrikseipp/rednotebook/discussions"
 
 developers = ["%(author)s <%(author_mail)s>" % locals()]
 artists = ["Ciaran"]


### PR DESCRIPTION
Summary of the changes in this pull request:

As mentioned in TODOs, I've added a "Give Feedback" option in Help menu.

(Copy of #550)

Copied suggestion:

I think that it would be better to redirect the user to `.../discussions/new/?category=ideas`. @jendrikseipp what do you think?