### PR TITLE
main_window.py: prevent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # next (unreleased)
-* No changes so far.
+* Fix python crash on start (#583, Max Krummenacher).
 
 # 2.22 (2021-04-25)
 * Add a "Give Feedback" button (#551, Rahul Jha).

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -25,6 +25,7 @@ import urllib.parse
 
 from gi.repository import Gdk, GdkPixbuf, GObject, Gtk, GtkSource, Pango
 
+from rednotebook.gui.options import OptionsManager
 from rednotebook import info, templates
 from rednotebook.gui import (
     browser,
@@ -39,7 +40,6 @@ from rednotebook.gui import (
 from rednotebook.gui.customwidgets import CustomComboBoxEntry, CustomListView
 from rednotebook.gui.exports import ExportAssistant
 from rednotebook.gui.menu import MainMenuBar
-from rednotebook.gui.options import OptionsManager
 from rednotebook.util import dates, filesystem, markup, urls, utils
 
 


### PR DESCRIPTION
With commit cbb9c0ea7d3e (on OpenSuse Leap 15.2, Python 3.6.12) python
crashes right after the start.

Reorder the import statments in main_window.py prevents this.

|  ./run
| Adding /home/mk/workspace/rednotebook to sys.path
| 2021-06-27 14:13:06,075 INFO     Writing log to file "/home/mk/.rednotebook/rednotebook.log"
| 2021-06-27 14:13:06,075 INFO     System encoding: utf-8
| 2021-06-27 14:13:06,075 INFO     Language code: de_CH
| *** Error in `python3': free(): invalid pointer: 0x0000561172769860 ***
| ./run: Zeile 20: 15634 Abgebrochen

Signed-off-by: Max Krummenacher <max.oss.09@gmail.com>

<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

## Summary of the changes in this pull request

* Prevent: Error in `python3': free(): invalid pointer

## Pull request checklist
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have added an entry in `CHANGELOG.md` including my name and issue and/or pull request number.
- [ ] If applicable: I have removed the corresponding entry in `TODO.md`.
