### PR TITLE
Fix horrid reverse DNS naming I introduced as it creates issues on De…

### DIFF
--- a/data/rednotebook.appdata.xml
+++ b/data/rednotebook.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <!-- https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-id-desktopapp -->
-  <id>app.rednotebook.rednotebook</id>
+  <id>rednotebook</id>
   <metadata_license>CC0-1.0</metadata_license>
   <!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-project_license -->
   <project_license>GPL-2.0-or-later</project_license>
@@ -42,7 +42,7 @@
   <translation type="gettext">rednotebook</translation>
 
   <!-- https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-launchable -->
-  <launchable type="desktop-id">app.rednotebook.rednotebook.desktop</launchable>
+  <launchable type="desktop-id">rednotebook.desktop</launchable>
 
   <!-- https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-provides -->
   <provides>

--- a/data/rednotebook.desktop
+++ b/data/rednotebook.desktop
@@ -2,15 +2,13 @@
 Version=1.0
 Name=RedNotebook
 GenericName=Journal
-GenericName[lt]=Žurnalas
 Comment=Daily journal with calendar, templates and keyword searching
-Comment[lt]=Kasdienis žurnalas su kalendoriumi, šablonais ir raktažodžių paieška
 Exec=rednotebook
 Icon=rednotebook
 Terminal=false
 Type=Application
 Categories=Office;Calendar;
 Keywords=Journal;Diary;Notes;Notebook;
-Keywords[lt]=Žurnalas;Dienoraštis;Užrašai;Pastabos;Užrašinė;
 StartupNotify=true
 X-GNOME-Gettext-Domain=rednotebook
+Name[en_GB]=rednotebook

--- a/data/rednotebook.desktop
+++ b/data/rednotebook.desktop
@@ -2,13 +2,15 @@
 Version=1.0
 Name=RedNotebook
 GenericName=Journal
+GenericName[lt]=Žurnalas
 Comment=Daily journal with calendar, templates and keyword searching
+Comment[lt]=Kasdienis žurnalas su kalendoriumi, šablonais ir raktažodžių paieška
 Exec=rednotebook
 Icon=rednotebook
 Terminal=false
 Type=Application
 Categories=Office;Calendar;
 Keywords=Journal;Diary;Notes;Notebook;
+Keywords[lt]=Žurnalas;Dienoraštis;Užrašai;Pastabos;Užrašinė;
 StartupNotify=true
 X-GNOME-Gettext-Domain=rednotebook
-Name[en_GB]=rednotebook

--- a/debian/copyright
+++ b/debian/copyright
@@ -15,7 +15,7 @@ Copyright: Copyright (C) 2008, 2009 Jonathan Wiltshire <debian@jwiltshire.org.uk
            Copyright (C) 2017-2022 Phil Wyett <philip.wyett@kathenas.org>
 License: GPL-2+
 
-Files: data/app.rednotebook.rednotebook.appdata.xml
+Files: data/rednotebook.appdata.xml
 Copyright: Copyright (C) 2008-2022 Jendrik Seipp <jendrikseipp@gmail.com>
            Copyright (C) 2017-2022 Phil Wyett <philip.wyett@kathenas.org>
 License: CC0-1.0

--- a/rednotebook/gui/options.py
+++ b/rednotebook/gui/options.py
@@ -74,7 +74,7 @@ class TickOption(Option):
 class AutostartOption(TickOption):
     def __init__(self):
         self.autostart_file = os.path.expanduser(
-            "~/.config/autostart/app.rednotebook.rednotebook.desktop"
+            "~/.config/autostart/rednotebook.desktop"
         )
         autostart_file_exists = os.path.exists(self.autostart_file)
         TickOption.__init__(

--- a/setup.py
+++ b/setup.py
@@ -128,12 +128,12 @@ parameters = {
         ]
     },
     "data_files": [
-        ("share/applications", ["data/app.rednotebook.rednotebook.desktop"]),
+        ("share/applications", ["data/rednotebook.desktop"]),
         (
             "share/icons/hicolor/scalable/apps",
             ["rednotebook/images/rednotebook-icon/rednotebook.svg"],
         ),
-        ("share/metainfo", ["data/app.rednotebook.rednotebook.appdata.xml"]),
+        ("share/metainfo", ["data/rednotebook.appdata.xml"]),
     ],
     "cmdclass": cmdclass,
     "extras_require": {


### PR DESCRIPTION
Fix horrid reverse DNS naming I introduced as it creates issues on Debian and Fedora with missing icons in gnome-shell activities and dash and most likely other DEs.

Apologies, I missed this in testing. Will require a new release.