### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -539,7 +539,7 @@ rednotebook (1.3.0-1) oneiric; urgency=low
 
   * New upstream release
 
- -- Jendrik Seipp <jendrikseipp@web.de>  Sun, 24 Jan 2012 18:08:10 +0200
+ -- Jendrik Seipp <jendrikseipp@web.de>  Tue, 24 Jan 2012 18:08:10 +0200
 
 rednotebook (1.2.0-1) oneiric; urgency=low
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,3 @@
-Name: rednotebook
 Bug-Database: https://github.com/jendrikseipp/rednotebook/issues
 Repository: https://github.com/jendrikseipp/rednotebook.git
 Repository-Browse: https://github.com/jendrikseipp/rednotebook

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,5 @@
 Name: rednotebook
+Bug-Database: https://github.com/jendrikseipp/rednotebook/issues
 Repository: https://github.com/jendrikseipp/rednotebook.git
 Repository-Browse: https://github.com/jendrikseipp/rednotebook
 Bug-Submit: https://github.com/jendrikseipp/rednotebook/issues


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).

* Fix day-of-week for changelog entry 1.3.0-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/rednotebook/363a28b8-d286-46fc-b122-14b77bc08986.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/363a28b8-d286-46fc-b122-14b77bc08986/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/363a28b8-d286-46fc-b122-14b77bc08986/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/363a28b8-d286-46fc-b122-14b77bc08986/diffoscope)).
