### PR TITLE
Add a script to merge rednotebook files into a rednotebook

### DIFF
--- a/scripts/rednotebook_merge.py
+++ b/scripts/rednotebook_merge.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#! /usr/bin/env python
 
-"""Merges two rednotebook directories
+"""Merge two RedNotebook directories.
 
-To merge .txt files into a destination rednotebook:
+To merge .txt files into a destination RedNotebook journal:
 
-1. Quit rednoteboot
-2. Run it again and do a backup
-3. Quit it
-4. Merge in your files:
+1. Click on "Save" within RedNotebook. 
+2. Do a backup.
+3. Quit RedNotebook.
+4. Merge in your files (adjust paths):
 
-   rednotebook-merge.py -n -d ~/.rednotebook/data -t "title" /path/to/*.txt
+   rednotebook-merge.py --dry-run --dest-dir ~/.rednotebook/data --title "my title" /path/to/*.txt
 
 You will see a log like this:
 
@@ -29,10 +29,10 @@ You will see a log like this:
 
 If that looks OK, then
 
-5. Run that again but without the -n flag
+5. Run that again but without the --dry-run flag.
 
 It should merge in the files. You can see things that were merged in since
-each item as an 'Added from <title>: /path/to/xxx.txt' before the merged text.
+each item as an 'Added from <my title>: /path/to/xxx.txt' before the merged text.
 """
 
 import argparse
@@ -41,7 +41,7 @@ import sys
 import yaml
 
 def doit(argv):
-    """Merge a list of files into another .rednotebook directory
+    """Merge a list of files into another RedNotebook directory
 
     Args:
         argv (list of str): Program arguments

--- a/scripts/rednotebook_merge.py
+++ b/scripts/rednotebook_merge.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+"""Merges two rednotebook directories
+
+To merge .txt files into a destination rednotebook:
+
+1. Quit rednoteboot
+2. Run it again and do a backup
+3. Quit it
+4. Merge in your files:
+
+   rednotebook-merge.py -n -d ~/.rednotebook/data -t "title" /path/to/*.txt
+
+You will see a log like this:
+
+    Updating file /home/sglass/.rednotebook/data/2023-02.txt
+       - merging day 1
+       - merging day 2
+       - added new day 3
+       - merging day 6
+       written
+    Updating file /home/sglass/.rednotebook/data/2023-03.txt
+       - merging day 1
+       - added new day 21
+       written
+    Adding new file 2023-04.txt
+       - added new day 2
+       written
+
+If that looks OK, then
+
+5. Run that again but without the -n flag
+
+It should merge in the files. You can see things that were merged in since
+each item as an 'Added from <title>: /path/to/xxx.txt' before the merged text.
+"""
+
+import argparse
+import os
+import sys
+import yaml
+
+def doit(argv):
+    """Merge a list of files into another .rednotebook directory
+
+    Args:
+        argv (list of str): Program arguments
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--dest-dir', type=str, required=True,
+        help='Rednotebook data directory to merge into')
+    parser.add_argument('-t', '--title', type=str, default='',
+        help='Title of source files, to use when merging')
+    parser.add_argument('src_files', type=str, nargs='+',
+        help='Files to merge in')
+    parser.add_argument('-n', '--dry-run', action='store_true',
+        help="Don't update destination files")
+    args = parser.parse_args(argv[1:])
+
+    for fname in args.src_files:
+        header = f'Added from {args.title}: {fname}:\n'
+
+        # Load data from the source file
+        with open(fname, encoding='utf-8') as inf:
+            in_data = yaml.safe_load(inf)
+
+        base = os.path.basename(fname)
+
+        # Figure out what the destination filename will be
+        dest_fname = os.path.join(args.dest_dir, base)
+
+        # If it exists, read it in, since we'll need to update it...
+        if os.path.exists(dest_fname):
+            with open(dest_fname, encoding='utf-8') as inf:
+                dest_data = yaml.safe_load(inf)
+            print(f'Updating file {dest_fname}')
+
+        # ...but if it doesn't exist, create it
+        else:
+            dest_data = {}
+            print(f'Adding new file {base}')
+
+        # Work through day by day, merging in the data
+        for day in sorted(in_data.keys()):
+            text = in_data[day]['text']
+
+            # If the day exists, append this text at the end...
+            if day in dest_data:
+                print(f'   - merging day {day}')
+                dest_data[day]['text'] += '\n\n' + header + text
+
+            # but if the day does not exist, create it
+            else:
+                print(f'   - added new day {day}')
+                dest_data[day] = {'text': header + text}
+
+        # Write out the resulting file, if requested
+        if not args.dry_run:
+            with open(dest_fname, 'w', encoding='utf-8') as outf:
+                yaml.dump(dest_data, outf)
+            print('   written')
+
+
+if __name__ == '__main__':
+    sys.exit(doit(sys.argv))

--- a/scripts/rednotebook_merge.py
+++ b/scripts/rednotebook_merge.py
@@ -4,6 +4,7 @@
 
 To merge .txt files into a destination RedNotebook journal:
 
+0. Install script requirements: "pip install PyYAML"
 1. Click on "Save" within RedNotebook. 
 2. Do a backup.
 3. Quit RedNotebook.
@@ -38,17 +39,19 @@ each item as an 'Added from <my title>: /path/to/xxx.txt' before the merged text
 import argparse
 import os
 import sys
+
 import yaml
 
+
 def doit(argv):
-    """Merge a list of files into another RedNotebook directory
+    """Merge a list of files into another RedNotebook directory.
 
     Args:
         argv (list of str): Program arguments
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--dest-dir', type=str, required=True,
-        help='Rednotebook data directory to merge into')
+        help='RedNotebook data directory to merge into')
     parser.add_argument('-t', '--title', type=str, default='',
         help='Title of source files, to use when merging')
     parser.add_argument('src_files', type=str, nargs='+',
@@ -60,13 +63,13 @@ def doit(argv):
     for fname in args.src_files:
         header = f'Added from {args.title}: {fname}:\n'
 
-        # Load data from the source file
+        # Load data from the source file.
         with open(fname, encoding='utf-8') as inf:
             in_data = yaml.safe_load(inf)
 
         base = os.path.basename(fname)
 
-        # Figure out what the destination filename will be
+        # Figure out what the destination filename will be.
         dest_fname = os.path.join(args.dest_dir, base)
 
         # If it exists, read it in, since we'll need to update it...
@@ -80,7 +83,7 @@ def doit(argv):
             dest_data = {}
             print(f'Adding new file {base}')
 
-        # Work through day by day, merging in the data
+        # Work through day by day, merging in the data.
         for day in sorted(in_data.keys()):
             text = in_data[day]['text']
 
@@ -89,12 +92,12 @@ def doit(argv):
                 print(f'   - merging day {day}')
                 dest_data[day]['text'] += '\n\n' + header + text
 
-            # but if the day does not exist, create it
+            # but if the day does not exist, create it.
             else:
                 print(f'   - added new day {day}')
                 dest_data[day] = {'text': header + text}
 
-        # Write out the resulting file, if requested
+        # Write out the resulting file, if requested.
         if not args.dry_run:
             with open(dest_fname, 'w', encoding='utf-8') as outf:
                 yaml.dump(dest_data, outf)


### PR DESCRIPTION
This can be used to merge one rednotebook directory into another.

I find this useful since there is apparently no cloud syncing available with rednotbook.

See the instructions at the top of the script.

<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

## Summary of the changes in this pull request

* TODO

## Pull request checklist
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [ ] I have added an entry in `CHANGELOG.md` including my name and issue and/or pull request number.
- [ ] If applicable: I have removed the corresponding entry in `TODO.md`.
