### PR TITLE
Use webkit API 4.1 where available or 4.0 if not.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python3:Depends},
          gir1.2-gtk-3.0,
          gir1.2-gtksource-4,
          gir1.2-pango-1.0,
-         gir1.2-webkit2-4.0,
+         gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
          python3-gi,
          python3-yaml
 Recommends: python3-enchant


### PR DESCRIPTION
<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

## Summary of the changes in this pull request

Use webkit API 4.1 where available or 4.0 if not.

Closes issues: #713

Note: Not a change I like to make as multiple runtime deps across builds creates more testing for me. However, rednotebook is small enough as a project that additional time needed is minimal.