### PR TITLE
Change to use new GitHub API for release tarball download.

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,9 +1,10 @@
 # See uscan(1) for format.
+# Also see: https://wiki.debian.org/debian/watch
 
 # Compulsory line, this is a version 4 file.
 version=4
 
-opts="repacksuffix=+ds,,dversionmangle=s/\+ds//,repack,compression=gz, \
-  filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%rednotebook-$1.tar.gz%" \
-  https://github.com/jendrikseipp/rednotebook/tags \
-  (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate
+opts="searchmode=plain,repacksuffix=+ds,,dversionmangle=s/\+ds//,repack,compression=gz, \
+filenamemangle=s%(?:.*?)?v?@ANY_VERSION@%@PACKAGE@-$1.tar.gz%" \
+https://api.github.com/repos/jendrikseipp/rednotebook/releases?per_page=50 \
+https://api.github.com/repos/[^/]+/[^/]+/tarball/v?@ANY_VERSION@


### PR DESCRIPTION
## Summary of the changes in this pull request

* Change to use new GitHub API for release tarball download.

  Ref: https://wiki.debian.org/debian/watch#GitHub
