### PR TITLE
Remove generated files in clean target (Closes: #1046202).

### DIFF
--- a/debian/clean
+++ b/debian/clean
@@ -1,0 +1,2 @@
+rednotebook.egg-info/
+build/locale/*/LC_MESSAGES/rednotebook.mo


### PR DESCRIPTION
Remove generated files in clean target (Closes: #1046202).

Bug report in Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1046202

Note: There are merge requests active to possibly remove 'egg-info' directories during natural 'dh_clean' target, but these are not in yet, so we add to the 'clean' target manually to fix and close the bug report.