### PR TITLE
rednotebook_merge: Avoid duplicate data when merging

### DIFF
--- a/scripts/rednotebook_merge.py
+++ b/scripts/rednotebook_merge.py
@@ -28,6 +28,11 @@ You will see a log like this:
        - added new day 2
        written
 
+It ends with a summary, e.g. Days already present 17, merged 161, added 71
+
+That means that 17 days already had the corresponding contents, 161 days were
+merged in and 71 new days were added.
+
 If that looks OK, then
 
 5. Run that again but without the --dry-run flag.
@@ -70,6 +75,9 @@ def doit(argv):
     )
     args = parser.parse_args(argv[1:])
 
+    present, merged, added = 0, 0, 0
+
+    merged = 0
     for fname in args.src_files:
         header = f"Added from {args.title}: {fname}:\n"
 
@@ -99,19 +107,29 @@ def doit(argv):
 
             # If the day exists, append this text at the end...
             if day in dest_data:
-                print(f"   - merging day {day}")
-                dest_data[day]["text"] += "\n\n" + header + text
+                if text in dest_data[day]["text"]:
+                    print(f"   - already present in day {day}")
+                    present += 1
+                else:
+                    print(f"   - merging day {day}")
+                    dest_data[day]["text"] += "\n\n" + header + text
+                    merged += 1
 
-            # but if the day does not exist, create it.
+            # but if the day does not exist, create it
             else:
                 print(f"   - added new day {day}")
                 dest_data[day] = {"text": header + text}
+                added += 1
 
         # Write out the resulting file, if requested.
         if not args.dry_run:
             with open(dest_fname, "w", encoding="utf-8") as outf:
                 yaml.dump(dest_data, outf)
             print("   written")
+
+    print(f"Days already present {present}, merged {merged}, added {added}")
+    if args.dry_run:
+        print("Dry run - no changes")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It is useful to be able to merge notebooks regularly across multiple machines. The existing script adds the new material again, even if a previous merge already added it.

Add a check for this, so that repeated merging will not create lots of duplicate text.

Also include a summary of what happened and mention a script dependency.

<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

## Summary of the changes in this pull request

* TODO

## Pull request checklist
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [ ] I have added an entry in `CHANGELOG.md` including my name and issue and/or pull request number.
- [ ] If applicable: I have removed the corresponding entry in `TODO.md`.
