### PR TITLE
Fix for Issue 778.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.36 (2024-10-24)
+* Fix: Categories with characters incompatible with the current locale opens (#778, Oussama Jarrousse).
+
 # 2.35 (2024-09-22)
 * Add option to auto-indent text in editor and activate it by default (#561, #562, Allen Benter, Varunjay Varma).
 

--- a/rednotebook/journal.py
+++ b/rednotebook/journal.py
@@ -540,7 +540,7 @@ class Journal(Gtk.Application):
     def categories(self):
         return sorted(
             set(itertools.chain.from_iterable(day.categories for day in self.days)),
-            key=locale.strxfrm,
+            key=utils.safe_strxfrm,
         )
 
     def get_entries(self, category):

--- a/rednotebook/util/utils.py
+++ b/rednotebook/util/utils.py
@@ -17,6 +17,7 @@
 # -----------------------------------------------------------------------
 
 import http.client
+import locale
 import logging
 import os.path
 import re
@@ -202,3 +203,14 @@ class StreamDuplicator:
     def close(self):
         for stream in self.streams:
             stream.close()
+
+def safe_strxfrm(value):
+    """
+    Safely apply locale-aware sorting. If locale.strxfrm fails, fall back to default sorting.
+    """
+    try:
+        return locale.strxfrm(value)
+    except OSError:
+        return value
+    except:
+        return value

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -11,10 +11,12 @@ def mock_month():
     day1 = Day(month, 1, {"text": "Example text", "Aria": {}})
     day2 = Day(month, 2, {"text": "More example text", "Aria": {}, "Opera":{}, "Étude":{}})
     day3 = Day(month, 3, {"text": "Another text", "Sonata": {}, "Prelude": {}, "Opera": {}, "Concerto":{}})
+    day4 = Day(month, 4, {"text": "Regression test for issue 778", "Opera":{}, "المُوَشَّح":{}})
 
     month.days[1] = day1
     month.days[2] = day2
     month.days[3] = day3
+    month.days[3] = day4
     
     yield month
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -16,7 +16,7 @@ def mock_month():
     month.days[1] = day1
     month.days[2] = day2
     month.days[3] = day3
-    month.days[3] = day4
+    month.days[4] = day4
     
     yield month
 
@@ -35,5 +35,6 @@ def test_categories(mock_month):
     journal.months = { (2024, 10): mock_month }
 
     # Assert the categories property returns expected categories sorted alphabetically
-    expected_categories = ['Aria', 'Concerto', 'Étude', 'Opera', 'Prelude', 'Sonata']
+    expected_categories = ['Aria', 'Concerto', 'Étude', 'Opera', 'Prelude', 'Sonata', 'المُوَشَّح']
+    
     assert journal.categories == expected_categories

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,37 @@
+import pytest
+
+from datetime import date
+from rednotebook.data import Month, Day  # Assuming you have access to these
+
+from rednotebook.journal import Journal
+
+@pytest.fixture
+def mock_month():
+    month = Month(2024, 10)
+    day1 = Day(month, 1, {"text": "Example text", "Aria": {}})
+    day2 = Day(month, 2, {"text": "More example text", "Aria": {}, "Opera":{}, "Étude":{}})
+    day3 = Day(month, 3, {"text": "Another text", "Sonata": {}, "Prelude": {}, "Opera": {}, "Concerto":{}})
+
+    month.days[1] = day1
+    month.days[2] = day2
+    month.days[3] = day3
+    
+    yield month
+
+
+def test_categories(mock_month):
+    # Create an empty journal instance
+    journal = Journal()
+
+    # Add a month with no days to the journal
+    journal.months = { (2024, 10): Month(2024, 10) }
+
+    # Ensure that the categories list is empty
+    assert journal.categories == [], "Expected no categories in an empty journal"
+
+    # Add a month with days to the journal
+    journal.months = { (2024, 10): mock_month }
+
+    # Assert the categories property returns expected categories sorted alphabetically
+    expected_categories = ['Aria', 'Concerto', 'Étude', 'Opera', 'Prelude', 'Sonata']
+    assert journal.categories == expected_categories


### PR DESCRIPTION
<!--By making a pull request, you agree to the following terms:

```
"The contributor understands and agrees that Jendrik Seipp shall have
the irrevocable and perpetual right to make and distribute copies of
any contribution, as well as to create and distribute collective works
and derivative works of any contribution, under the GPL or under any
other open source license approved by the Open Source Initiative."
```
-->

## Summary of the changes in this pull request

* Added rednotebook.utils.safe_strxfrm() fixing issue-778 and updated rednotebook.journal.Journal.categories() to use utils.safe_strxfrm() in sorting categories instead of locale.strxfrm() that was raising OSError in case of characters incompatible with the current locale
* Added tests/test_journal.py that contains a the function test_categories() that tests journal.categories including the specific case of issue-778.

## Pull request checklist
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have added an entry in `CHANGELOG.md` including my name and issue and/or pull request number.
- [] If applicable: I have removed the corresponding entry in `TODO.md`.
