### PR TITLE
Switch 'Build-Depends' 'python3' to 'python3-all'.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/jendrikseipp/rednotebook.git
 Vcs-Browser: https://github.com/jendrikseipp/rednotebook
 Build-Depends: debhelper-compat (= 13),
                gettext,
-               python3,
+               python3-all,
                python3-setuptools,
                dh-python
 


### PR DESCRIPTION
Switch 'Build-Depends' 'python3' to 'python3-all'.

python3-all: package depending on all supported Python 3 runtime versions.

https://packages.debian.org/unstable/python3-all

Ref: https://wiki.debian.org/Python/LibraryStyleGuide
