### PR TITLE
Update 'Standards-Version' to latest and remove no longer needed 'Rules-Requires-Root: no'.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,7 @@ Source: rednotebook
 Maintainer: Jendrik Seipp <jendrikseipp@gmail.com>
 Section: text
 Priority: optional
-Standards-Version: 4.7.0
-Rules-Requires-Root: no
+Standards-Version: 4.7.2
 Homepage: https://rednotebook.app
 Vcs-Git: https://github.com/jendrikseipp/rednotebook.git
 Vcs-Browser: https://github.com/jendrikseipp/rednotebook


### PR DESCRIPTION
Update 'Standards-Version' to latest and remove no longer needed 'Rules-Requires-Root: no'.

