### PR TITLE
Keyboard shortcut failure with small window resize

### DIFF
--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -249,6 +249,21 @@ class MainWindow:
         # Exit fullscreen mode with ESC.
         if event.keyval == Gdk.KEY_Escape and self.is_fullscreen:
             self.toggle_fullscreen()
+            
+        # Handle day navigation shortcuts even if they are hidden due to resize.
+        if event.state & Gdk.ModifierType.CONTROL_MASK:
+            if event.keyval == Gdk.KEY_Page_Up:
+                self.on_back_one_day_button_clicked(None)
+                return True
+            elif event.keyval == Gdk.KEY_Page_Down:
+                self.on_forward_one_day_button_clicked(None)
+                return True
+
+        if event.state & Gdk.ModifierType.MOD1_MASK: # Alt key
+            if event.keyval == Gdk.KEY_Home:
+                self.on_today_button_clicked(None)
+                return True
+        
 
     # TRAY-ICON / CLOSE --------------------------------------------------------
 

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -262,7 +262,7 @@ class MainWindow:
             (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_p): self.on_preview_or_edit_toggle,
 
             # Find shortcut
-            (Gdk.Modifier.CONTROL_MASK, Gdk.KEY_F): self.on_find_activated,
+            (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_F): self.on_find_activated,
         }
 
         # Check if the current key combination matches any shortcut.
@@ -272,14 +272,14 @@ class MainWindow:
                 return True 
         return False
 
-def on_preview_or_edit_toggle(self, widget):
-    """Toggle between preview and edit mode (Ctrl+P)"""
-    self.change_mode(preview=not self.preview_mode)
-
-def on_find_activated(self, widget):
-    """Activate find/search (Ctrl+F)"""
-    self.search_box.entry.grab_focus()
-            
+    def on_preview_or_edit_toggle(self, widget):
+        """Toggle between preview and edit mode (Ctrl+P)"""
+        self.change_mode(preview=not self.preview_mode)
+    
+    def on_find_activated(self, widget):
+        """Activate find/search (Ctrl+F)"""
+        self.search_box.entry.grab_focus()
+                
         
 
     # TRAY-ICON / CLOSE --------------------------------------------------------

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -265,7 +265,7 @@ class MainWindow:
         for (modifier, keyval), callback in shortcuts.items():
             if (event.state & modifier) == modifier and event.keyval == keyval:
                 callback(None)
-                return True 
+                return True
         return False
 
     def on_preview_or_edit_toggle(self, widget):

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -249,23 +249,19 @@ class MainWindow:
         # Exit fullscreen mode with ESC.
         if event.keyval == Gdk.KEY_Escape and self.is_fullscreen:
             self.toggle_fullscreen()
-            
-        # Global keyboard shortcuts that work even if buttons are hidden.
-        # This maps key combinations to callback methods. 
+        
+        # Handle keyboard shortcuts that work even if buttons are hidden
+        # due to window resizing
         shortcuts = {
             # Navigation shortcuts
             (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_Page_Up): self.on_back_one_day_button_clicked,
             (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_Page_Down): self.on_forward_one_day_button_clicked,
             (Gdk.ModifierType.MOD1_MASK, Gdk.KEY_Home): self.on_today_button_clicked,
-
             # Preview/Edit shortcuts
             (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_p): self.on_preview_or_edit_toggle,
-
             # Find shortcut
             (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_F): self.on_find_activated,
         }
-
-        # Check if the current key combination matches any shortcut.
         for (modifier, keyval), callback in shortcuts.items():
             if (event.state & modifier) == modifier and event.keyval == keyval:
                 callback(None)
@@ -279,9 +275,8 @@ class MainWindow:
     def on_find_activated(self, widget):
         """Activate find/search (Ctrl+F)"""
         self.search_box.entry.grab_focus()
-                
-        
 
+    
     # TRAY-ICON / CLOSE --------------------------------------------------------
 
     def setup_tray_icon(self):

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -265,12 +265,12 @@ class MainWindow:
             (Gdk.Modifier.CONTROL_MASK, Gdk.KEY_F): self.on_find_activated,
         }
 
-    # Check if the current key combination matches any shortcut.
-    for (modifier, keyval), callback in shortcuts.items():
-        if (event.state & modifier) == modifier and event.keyval == keyval:
-            callback(None)
-            return True 
-    return False
+        # Check if the current key combination matches any shortcut.
+        for (modifier, keyval), callback in shortcuts.items():
+            if (event.state & modifier) == modifier and event.keyval == keyval:
+                callback(None)
+                return True 
+        return False
 
 def on_preview_or_edit_toggle(self, widget):
     """Toggle between preview and edit mode (Ctrl+P)"""

--- a/rednotebook/gui/main_window.py
+++ b/rednotebook/gui/main_window.py
@@ -250,19 +250,36 @@ class MainWindow:
         if event.keyval == Gdk.KEY_Escape and self.is_fullscreen:
             self.toggle_fullscreen()
             
-        # Handle day navigation shortcuts even if they are hidden due to resize.
-        if event.state & Gdk.ModifierType.CONTROL_MASK:
-            if event.keyval == Gdk.KEY_Page_Up:
-                self.on_back_one_day_button_clicked(None)
-                return True
-            elif event.keyval == Gdk.KEY_Page_Down:
-                self.on_forward_one_day_button_clicked(None)
-                return True
+        # Global keyboard shortcuts that work even if buttons are hidden.
+        # This maps key combinations to callback methods. 
+        shortcuts = {
+            # Navigation shortcuts
+            (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_Page_Up): self.on_back_one_day_button_clicked,
+            (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_Page_Down): self.on_forward_one_day_button_clicked,
+            (Gdk.ModifierType.MOD1_MASK, Gdk.KEY_Home): self.on_today_button_clicked,
 
-        if event.state & Gdk.ModifierType.MOD1_MASK: # Alt key
-            if event.keyval == Gdk.KEY_Home:
-                self.on_today_button_clicked(None)
-                return True
+            # Preview/Edit shortcuts
+            (Gdk.ModifierType.CONTROL_MASK, Gdk.KEY_p): self.on_preview_or_edit_toggle,
+
+            # Find shortcut
+            (Gdk.Modifier.CONTROL_MASK, Gdk.KEY_F): self.on_find_activated,
+        }
+
+    # Check if the current key combination matches any shortcut.
+    for (modifier, keyval), callback in shortcuts.items():
+        if (event.state & modifier) == modifier and event.keyval == keyval:
+            callback(None)
+            return True 
+    return False
+
+def on_preview_or_edit_toggle(self, widget):
+    """Toggle between preview and edit mode (Ctrl+P)"""
+    self.change_mode(preview=not self.preview_mode)
+
+def on_find_activated(self, widget):
+    """Activate find/search (Ctrl+F)"""
+    self.search_box.entry.grab_focus()
+            
         
 
     # TRAY-ICON / CLOSE --------------------------------------------------------


### PR DESCRIPTION
## Problem
When the left sidebar is resized to hide toolbar buttons (Back, Today, Forward), 
the keyboard shortcuts (Ctrl+PageUp, Alt+Home, Ctrl+PageDown) no longer work 
because GTK doesn't trigger accelerators for hidden widgets.

## Solution
Handle navigation and preview shortcuts directly in the key press event handler 
instead of relying solely on button accelerators. This ensures they work 
regardless of toolbar visibility.

## Testing
- [ ] Resize sidebar to hide navigation buttons
- [ ] Verify Ctrl+PageUp/Down navigation shortcuts still work
- [ ] Verify Alt+Home (go to today) still works
- [ ] Verify Ctrl+P (preview toggle) still works
- [ ] Verify Ctrl+F (find) still works

Fixes #887