### PR TITLE
Fix reading journal files with string day numbers (#897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Fix segfault on Wayland when setting the window icon (#806, @sjg20)
+* Fix reading journal files that store day numbers as strings (#897, @SAY-5)
 
 # 2.42 (2025-12-28)
 * Update help concerning math formulas (#97, #855, @jendrikseipp).

--- a/rednotebook/data.py
+++ b/rednotebook/data.py
@@ -293,6 +293,7 @@ class Month:
         month_content = month_content or {}
         self.days = {}
         for day_number, day_content in month_content.items():
+            day_number = int(day_number)
             self.days[day_number] = Day(self, day_number, day_content)
 
         self.edited = False

--- a/tests/test_day.py
+++ b/tests/test_day.py
@@ -12,6 +12,12 @@ def test_to_string():
     assert str(day) == str_version
 
 
+def test_string_day_keys():
+    month = Month(2026, 7, {"1": {"text": "hello"}})
+    assert list(month.days) == [1]
+    assert month.get_day(1).text == "hello"
+
+
 def test_hashtags():
     month = Month(2000, 10)
     day = Day(month, 20)


### PR DESCRIPTION
## Summary of the changes in this pull request

* Coerce day numbers to `int` when constructing a `Month`, so journal files whose day keys are stored as strings load correctly instead of failing with `TypeError: 'str' object cannot be interpreted as an integer` (#897).

## Pull request checklist
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have added an entry in `CHANGELOG.md` including my name and issue and/or pull request number.
- [ ] If applicable: I have removed the corresponding entry in `TODO.md`.
