### PR TITLE
fix: cast day_number to int when loading month content

### DIFF
--- a/rednotebook/data.py
+++ b/rednotebook/data.py
@@ -293,6 +293,7 @@ class Month:
         month_content = month_content or {}
         self.days = {}
         for day_number, day_content in month_content.items():
+            day_number = int(day_number)
             self.days[day_number] = Day(self, day_number, day_content)
 
         self.edited = False


### PR DESCRIPTION
Fixes #897

YAML can deserialize dictionary keys as strings depending on the document format. When that happens, `datetime.date()` in `Day.__init__()` crashes with `TypeError: 'str' object cannot be interpreted as an integer` because the day number is still a string.

Casting to `int()` in `Month.__init__()` before constructing the `Day` fixes the crash.

-- saschabuehrle