### PR TITLE
Restore old backup filename format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Fix segfault on Wayland when setting the window icon (#806, @sjg20)
 * Fix reading journal files that store day numbers as strings (#897, @SAY-5)
+* Restore the old backup filename format, dropping the journal title suffix (#884, @jendrikseipp)
 
 # 2.42 (2025-12-28)
 * Update help concerning math formulas (#97, #855, @jendrikseipp).

--- a/rednotebook/backup.py
+++ b/rednotebook/backup.py
@@ -112,12 +112,7 @@ class Archiver:
         return last_backup_age
 
     def _get_backup_file(self):
-        if self.journal.title == "data":
-            name = ""
-        else:
-            name = "-" + self.journal.title
-
-        proposed_filename = f"RedNotebook-Backup{name}-{datetime.date.today()}.zip"
+        proposed_filename = f"RedNotebook-Backup-{datetime.date.today()}.zip"
         proposed_directory = self.journal.config.read("lastBackupDir", os.path.expanduser("~"))
 
         backup_dialog = self.journal.frame.builder.get_object("backup_dialog")


### PR DESCRIPTION
Fixes #884 by removing the journal-title suffix that was being appended to backup filenames, restoring the historic `RedNotebook-Backup-<date>.zip` naming so old and new backups share the same format.

Generated with [Claude Code](https://claude.ai/code)